### PR TITLE
Rijksmuseum LIDO O'Keeffe data

### DIFF
--- a/data/rma/lido/RMA_OKeeffeData.xml
+++ b/data/rma/lido/RMA_OKeeffeData.xml
@@ -1,0 +1,10769 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/281436</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.281436</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">L'Hiver, cinquieme avenue</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F25501-BX</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1896</lido:earliestDate>
+                                <lido:latestDate>1896</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                            <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.70528</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Fillon &amp; Heuse</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">281436</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F25501-BX</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.281436</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-09-06T16:23:28</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{EB2B008A-8C30-4BBE-B4E8-BDBBEFF31D43}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/281435</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.281435</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">L'Hiver, cinquieme avenue</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F25501-BW</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1896</lido:earliestDate>
+                                <lido:latestDate>1896</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                            <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.70528</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Fillon &amp; Heuse</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">281435</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F25501-BW</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.281435</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-09-06T16:23:28</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0B402D6A-E29D-42F7-949C-9753D0A5DC1B}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/251879</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.251879</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van Miss S.R</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17771</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>205</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>140</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>300</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>207</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1904</lido:earliestDate>
+                                <lido:latestDate>1904</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2</lido:conceptID>
+                                <lido:term lido:pref="alternative">61BB2</lido:term>
+                                <lido:term xml:lang="en">historical persons - BB - woman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">251879</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17771</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.251879</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:37</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E1BE0379-EB74-47C6-AEC4-CF99ADD673E4}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/RCojphXB3EN808tGOX6VM4FNl7FbxVobZFvRyCGkngTQyNgRGzrWWC1ujEF-FXRn2pWUuo57RWTuG-3VXbJ9rXfmB1k=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/251878</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.251878</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spring 1901</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17770</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1901</lido:earliestDate>
+                                <lido:latestDate>1901</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">251878</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17770</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.251878</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:36</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{F869F3E0-4D5E-42F1-92A8-D1842AEB3569}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/IMPbjXF-ai5mIV7FVJybmR3vMJRGApixjs1tVIyyG7qcfYJiMdXGW7Rzv6iajPdcdruSTvbR9jFtPNx7OnxqEE1m2cw=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/250840</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.250840</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van Katherine Stieglitz</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Katherine, 1905</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17653</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>207</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>169</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>302</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>210</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1905</lido:earliestDate>
+                                <lido:latestDate>1905</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2(STIEGLITZ, KATHERINE)11</lido:conceptID>
+                                <lido:term lido:pref="alternative">61BB2(STIEGLITZ, KATHERINE)11</lido:term>
+                                <lido:term xml:lang="en">historical person (STIEGLITZ, KATHERINE) - BB - woman - historical person (STIEGLITZ, KATHERINE) portrayed alone</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">250840</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17653</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.250840</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:36</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{49D349A6-0AAE-46AC-90C6-1C85B419D2F3}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/OMhTm9j-w2raFpA14Mg3nLmdq9laGUGXXc9EWV_-qp_0wRfGB2Gzu5JZkTXEFcTHI7U5LoKEH8y70tEaDAMg6Z_QBP8=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/273988</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.273988</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300162872</lido:conceptID>
+                        <lido:term xml:lang="en">stereograph</lido:term>
+                        <lido:term xml:lang="nl">stereofoto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Wildey Monument, Baltimore, Md.</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F11219</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.85069</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Chase, William Merrit</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1849-11-01</lido:earliestDate>
+                                        <lido:latestDate>1916-10-15</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1860</lido:earliestDate>
+                                <lido:latestDate>1890</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58618</lido:conceptID>
+                            <lido:term xml:lang="en">third quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">derde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                            <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300054225</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotografie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1994</lido:earliestDate>
+                                <lido:latestDate>1994</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">273988</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F11219</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.273988</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-09-07T15:51:34</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{46F5799D-A617-4D2D-81B9-55BB98BC7DD7}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/sufs9OtRmNnZLFCaDQhLRsmctAW_ptkmQ22GHc7zqTCmGXig_6eqU4WAgIeK6ANZXOkQqnmlztbRGmFUdEzFLDLSJOE=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/712237</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.712237</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Flat Iron Building</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2017-206-26</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>168</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>84</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>293</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>208</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1903</lido:earliestDate>
+                                <lido:latestDate>1903</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300014224</lido:conceptID>
+                                    <lido:term xml:lang="en">cardboard</lido:term>
+                                    <lido:term xml:lang="nl">karton</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2018-03-21</lido:earliestDate>
+                                <lido:latestDate>2018-03-21</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.257</lido:conceptID>
+                            <lido:term xml:lang="en">loan</lido:term>
+                            <lido:term xml:lang="nl">bruikleen</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:creditLine xml:lang="en">On loan from J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Bruikleen van J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">712237</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2017-206-26</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.712237</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-07-17T04:39:28</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{D749A24D-D972-4E04-BC56-88785C75C1DA}</lido:resourceID>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/712236</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.712236</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">A Snapshot</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2017-206-25</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>137</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>169</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>280</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>200</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>296</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>210</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">secundaire drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1911</lido:earliestDate>
+                                <lido:latestDate>1911</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2018-03-21</lido:earliestDate>
+                                <lido:latestDate>2018-03-21</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.257</lido:conceptID>
+                            <lido:term xml:lang="en">loan</lido:term>
+                            <lido:term xml:lang="nl">bruikleen</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:creditLine xml:lang="en">On loan from J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Bruikleen van J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">712236</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2017-206-25</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.712236</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-07-17T04:39:18</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{B46EEDBD-8567-47CD-9DAB-4E488B241076}</lido:resourceID>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/510885</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.510885</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">An Icy Night</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2012-11</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectDescriptionWrap>
+                    <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Nachtfoto: met ijs bedekte bomen aan Park Avenue (bij 63rd Street), New York City.</lido:descriptiveNoteValue>
+                    </lido:objectDescriptionSet>
+                </lido:objectDescriptionWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>129</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>159</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>205</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>298</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1898-01</lido:earliestDate>
+                                <lido:latestDate>1903</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300015012</lido:conceptID>
+                                    <lido:term xml:lang="en">ink</lido:term>
+                                    <lido:term xml:lang="nl">inkt</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2012</lido:earliestDate>
+                                <lido:latestDate>2012</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/26D</lido:conceptID>
+                                <lido:term lido:pref="alternative">26D</lido:term>
+                                <lido:term xml:lang="en">frost, freezing weather</lido:term>
+                                <lido:term xml:lang="nl">vorst, vrieskou</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/219504</lido:objectID>
+                                <lido:objectNote>Électricité : ten advertising photographs by Man Ray</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/219502</lido:objectID>
+                                <lido:objectNote>Électricité : tien reclamefoto's van Man Ray</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:term xml:lang="en">copyright</lido:term>
+                        <lido:term xml:lang="nl">auteursrecht</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>erven Alfred Stieglitz/Pictoright</lido:appellationValue>
+                        </lido:legalBodyName>
+                    </lido:rightsHolder>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">510885</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2012-11</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.510885</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:52:07</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E1F66DFE-40AA-4B33-AB85-E4E7890EDB36}</lido:resourceID>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsHolder>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>erven Alfred Stieglitz/Pictoright</lido:appellationValue>
+                            </lido:legalBodyName>
+                        </lido:rightsHolder>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434710</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434710</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.28649</lido:conceptID>
+                        <lido:term xml:lang="en">magazine</lido:term>
+                        <lido:term xml:lang="nl">tijdschrift</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.26882</lido:conceptID>
+                        <lido:term xml:lang="nl">fotoboek</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417204">
+                        <lido:appellationValue xml:lang="nl">Camera Work (A photographic Quarterly. Edited and published by Alfred Stieglitz New York)</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="title">
+                        <lido:inscriptionTranscription>CAMERA WORK A PHOTOGRAPHIC QUARTERLY EDITED AND PUBLISHED BY ALFRED STIEGLITZ NEW YORK</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="date">
+                        <lido:inscriptionTranscription>NUMBER XXXII MDCCCCX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>EASTMAN ES PLATINUM In this paper we offer a sepia platinum of highest quality - a new hot bath sepia, rich in tone and printing quality - a pure platinum paper coated on buff stock in two surfaces - smooth and rough. EASTMAN KODAK CO., Rochester, N.Y.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-230</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectDescriptionWrap>
+                    <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">nummer XXXII MDCCCCX (nr. 32, 1910)</lido:descriptiveNoteValue>
+                    </lido:objectDescriptionSet>
+                </lido:objectDescriptionWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>340</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>214</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">thickness</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">dikte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>10</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">kaft</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1910</lido:earliestDate>
+                                <lido:latestDate>1910</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434711</lido:objectID>
+                                <lido:objectNote>Portret van een vrouw met op de achtergrond Japanse prenten</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434712</lido:objectID>
+                                <lido:objectNote>Schetsende man in rotslandschap</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434713</lido:objectID>
+                                <lido:objectNote>Gezicht op Harlech kasteel</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434714</lido:objectID>
+                                <lido:objectNote>Landschap met water</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434715</lido:objectID>
+                                <lido:objectNote>Gezicht op The White House vanaf het water</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604714</lido:objectID>
+                                <lido:objectNote>Naakte vrouw</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604716</lido:objectID>
+                                <lido:objectNote>Naakte man op de rug gezien</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604715</lido:objectID>
+                                <lido:objectNote>Ninth Movement</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434716</lido:objectID>
+                                <lido:objectNote>Portret van Alvin Langdon Coburn en zijn moeder</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434710</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-230</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434710</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-27T11:44:46</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{A6ECBD07-FCA3-458C-A85E-5F88A99DDB0D}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh4.ggpht.com/GaBkSdRmiBzzuci7d0LPxQALBTL5veUxLn1Rc-kLfrjA2bo-kYeIiJzOW71OMb1GS_PO39PowMDNLfGzJZcAphKvrdFa=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434493</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434493</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op het schip de Mauretania in New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Mauretania</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>Stieglitz "The Mauretania" 1910</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>B</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in pen</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-226</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>209</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>164</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>300</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>209</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1910</lido:earliestDate>
+                                <lido:latestDate>1910</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C26(+35)</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C26(+35)</lido:term>
+                                <lido:term xml:lang="en">steamsailer (+ propulsion of vehicle, ship, etc. by steam)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434493</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-226</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434493</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E66C2DBF-F049-492A-AF46-0DD3403C4551}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/qiM82bHNFlwuRl1FfrD125R_xSxuaIcxATH7DZTjXNFXWCuef2sWFd6O1Z4JQw7CJXobIeb3FMXpi5oeW4h3bYnf6Og=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434492</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434492</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht vanuit het raam van Alfred Stieglitz in New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Snapshot - From my Window, New York</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>JES [?] 51880P</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 07 [?]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-225</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>185</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>130</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>295</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>203</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1907</lido:earliestDate>
+                                <lido:latestDate>1907</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41A33</lido:conceptID>
+                                <lido:term lido:pref="alternative">41A33</lido:term>
+                                <lido:term xml:lang="en">window</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434492</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-225</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434492</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9597426F-37B7-4556-BF4D-B2B29F3CE5C0}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/4UgVcbs3Xr-EvGawQlUFy3LkNMPrBlsPjvqDeY9RUOaCwJPl7Kz8vfGrhcYt7XhMbbFnBqO5k_jqQHO75QcFmGjyOkI=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434491</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434491</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Old and New New York</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>Alfred Stieglitz Old and New New York (1910) from: Camera Work No. XXXVI MDCCCCX!</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-224</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>203</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>158</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>280</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>207</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>301</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>207</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">secundaire drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1910</lido:earliestDate>
+                                <lido:latestDate>1910</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434491</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-224</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434491</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{6E84F3AC-66B5-4E41-8353-8F5DF1372EF3}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh6.ggpht.com/nxOnmRIw2umBhlEVUwvrmZNmO7-JwwBqPB4a25qeD5BWDiYaZ2kV5CLqFDvhc6KPABlimkk0smVlFhv--FiFpS26xwhP=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434490</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434490</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op de rivier de Hudson en op New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The City Across the River</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>36:7</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-223</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>200</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>160</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>300</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>210</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1910</lido:earliestDate>
+                                <lido:latestDate>1910</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I1</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I1</lido:term>
+                                <lido:term xml:lang="en">city-view in general; 'veduta'</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.98448</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="nl">Hudson</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434490</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-223</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434490</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:40</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{F84E541A-7B58-415A-882C-33A11138AC41}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/mtvYC1aURZKe7hY4mP9Ad8OHHG0erKOduSGp1KCm1NIMSB6SxzeD4jdKAJY436FJx27iTiV5OhSxICGBSqo_PGD-bX4=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434489</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434489</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in Parijs</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">A Snapshot; Paris</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-222</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>137</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>174</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>281</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>200</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1911</lido:earliestDate>
+                                <lido:latestDate>1911</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434489</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-222</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434489</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:40</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{317E10B2-4E81-4A7C-9397-FC57DC504AD7}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/HfXSuUJsY501-xyRddjwayDpIsu6mVLS9JZggseqNT1cfSog8HqagexXt8a3-7qPSDgBJzhwsYsxyl9LwE1FfFQkAg=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434487</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434487</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Op de renbaan</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Going to the Start</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-221</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>213</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>190</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>234</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>209</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1904</lido:earliestDate>
+                                <lido:latestDate>1904</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C21213</lido:conceptID>
+                                <lido:term lido:pref="alternative">43C21213</lido:term>
+                                <lido:term xml:lang="en">race-track</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434487</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-221</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434487</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{D53356B6-8857-4BAD-9419-B8C25A6E297A}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/q2wVqzLZxVEWaSOZCIWSptsPFRzsroF0Hj-VI-D3lKW4lppQLGp108mCi4dtn70u06LvzFfMKOSxaCDLtdLUHq92RFQ=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434486</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434486</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Street - Design for a Poster</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>e [??] W [?]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-220</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>176</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>134</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>304</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>211</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1903</lido:earliestDate>
+                                <lido:latestDate>1903</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64336</lido:conceptID>
+                            <lido:term xml:lang="en">third quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">derde kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434486</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-220</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434486</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{77E77CE8-ADAE-47FC-8534-4BEDD1E8C94B}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/SHRuCzl7fdijYP4FtyYJzs7wR4hA_saEc5umJ2AhBYs7OiTSba7G8Y6wwnyuLOvNjEkIi-BS7NsQxJ5vMcf15_Pd_O4=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434488</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434488</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Stadsgezicht van New York</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The City of Ambition</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 9584 [?] -7 [?] en doorgestreept: AS 9582-2</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 70767 [?] (A)</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-218</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>223</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>169</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>303</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>209</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1911</lido:earliestDate>
+                                <lido:latestDate>1911</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                            <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                            <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2005</lido:earliestDate>
+                                <lido:latestDate>2005</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I1</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I1</lido:term>
+                                <lido:term xml:lang="en">city-view in general; 'veduta'</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434488</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-218</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434488</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{CFC2EB96-BBF6-4DE4-B074-ADDFCE8C14B7}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/qnWIOVkOWxPwabnxjCSjjDrYbAgD7GsJmWVVLuxcALW3QnZlALUlivq5Ux24mKcXsKewXr3CMyfLyIUjPP15IaqwTD8=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718467</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718467</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Paardenrace</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. XVII.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Going to the post by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-53</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>129</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>119</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1900</lido:earliestDate>
+                                <lido:latestDate>1905</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C2121</lido:conceptID>
+                                <lido:term lido:pref="alternative">43C2121</lido:term>
+                                <lido:term xml:lang="en">horse-racing</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                                <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718467</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-53</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718467</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:59:51</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{3930CEB1-5E55-4046-9738-F15E1BDBC605}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718453</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718453</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spoorlijnen met stoomtrein</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. X.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>The hand of man by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-46</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>109</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>142</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1900</lido:earliestDate>
+                                <lido:latestDate>1905</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.552983</lido:conceptID>
+                                    <lido:term xml:lang="nl">tweekleurenautotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C1511</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C1511</lido:term>
+                                <lido:term xml:lang="en">railway, train</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                                <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718453</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-46</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718453</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:59:48</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{B8AE2C1F-40D5-4E7A-A7F1-ABB3D224A500}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718441</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718441</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht bij nacht</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. VIII.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Reflections night by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-44</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>109</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>142</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1900</lido:earliestDate>
+                                <lido:latestDate>1905</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.552983</lido:conceptID>
+                                    <lido:term xml:lang="nl">tweekleurenautotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/23R14</lido:conceptID>
+                                <lido:term lido:pref="alternative">23R14</lido:term>
+                                <lido:term xml:lang="en">night</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                                <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718441</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-44</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718441</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:59:45</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{268B73D2-733D-4F7C-8483-0CE9F082DB7A}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/609302</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.609302</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Twee vrouwen op een strand</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Strassenklatsch</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1468-46</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>122</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>209</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1889</lido:earliestDate>
+                                <lido:latestDate>1899</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7000084</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Germany</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Duitsland</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109394</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Büxenstein &amp; Comp., Georg</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.134385</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Becker, Julius</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H133</lido:term>
+                                <lido:term xml:lang="en">beach</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                                <lido:term lido:pref="alternative">31D15</lido:term>
+                                <lido:term xml:lang="en">adult woman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C21</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C21</lido:term>
+                                <lido:term xml:lang="en">ships (in general)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.609180</lido:objectID>
+                                <lido:objectNote>Die Kunst in der Photographie 1899</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">609302</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1468-46</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.609302</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-08T17:02:38</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{524DB0C4-402E-4147-A6CB-647F8F94E1A2}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/DsR_9CdDaMywuI7JqB-Pcuq0R_DPr-1bt0ald3iiT2B-g9yzuCux-JNRylt5Y8GRO2Tptj1Lglpw0HxbA--MMPOLAw=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/695950</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.695950</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Drietal boten worden opgewacht door een groep mensen op het strand</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Landing of the Boats</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1187A-13</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>76</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>205</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Photochrome Engraving Co.</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C24</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C24</lido:term>
+                                <lido:term xml:lang="en">sailing-ship, sailing-boat</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H133</lido:term>
+                                <lido:term xml:lang="en">beach</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.695912</lido:objectID>
+                                <lido:objectNote>Camera notes / The Camera Club of New York</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">695950</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1187A-13</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.695950</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:13:30</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{8B2D7D78-05AB-496B-8E12-AE14BF7337A0}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/lpja5XYhcLAGHqwvJnm5PFq5dT17JYcIdA43QYTAZZHOdFb9g8Hpdgm_1fpCdaWm4RBiCX_jt2mK6yg9JxR5ZWzq4pES=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698117</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698117</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van een onbekende vrouw</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>BX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1184B-223</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>139</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>80</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1898</lido:earliestDate>
+                                <lido:latestDate>1903</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2</lido:conceptID>
+                                <lido:term lido:pref="alternative">61BB2</lido:term>
+                                <lido:term xml:lang="en">historical persons - BB - woman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.697238</lido:objectID>
+                                <lido:objectNote>Photographische Mittheilungen</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698117</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1184B-223</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698117</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T14:33:22</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0E280B39-B49A-4774-9CBA-A952E5A894C7}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/aPMWpttxa6oUszGHrpIBxV7GABS0Jsdcrp6qcUiUe5VlUSuIyc-coxJ2612M81SlZod7pqJiJvw1fnnSBVt0no8i7Lw=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698107</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698107</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spoorlijnen met stoomtrein</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Hand of Man</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>BX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1184B-220</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>89</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>120</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1898</lido:earliestDate>
+                                <lido:latestDate>1903</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C1511</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C1511</lido:term>
+                                <lido:term xml:lang="en">railway, train</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.697238</lido:objectID>
+                                <lido:objectNote>Photographische Mittheilungen</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698107</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1184B-220</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698107</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T14:33:19</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{C6B665CE-AA19-49EC-B650-AD60FE197618}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/Bc9slaZnmqDKAwt2z5Vi4aX1zQBtu_2N3vQyZL25CvibKbbxAvmvbwPbBXQSVjcLYUyyzkm8BmpR9fgPgR0aT-S0cRU=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698721</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698721</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Onbekende mannen op een kar met vaten met vermoedelijk Chanti</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Chianti</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1104A-2</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>146</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>113</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.55993</lido:conceptID>
+                                    <lido:term xml:lang="en">maker</lido:term>
+                                    <lido:term xml:lang="nl">vervaardiger</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1889</lido:earliestDate>
+                                <lido:latestDate>1894</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Photochrome Engraving Co.</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.55993</lido:conceptID>
+                                    <lido:term xml:lang="en">maker</lido:term>
+                                    <lido:term xml:lang="nl">vervaardiger</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61B2</lido:conceptID>
+                                <lido:term lido:pref="alternative">61B2</lido:term>
+                                <lido:term xml:lang="en">historical persons</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C123</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C123</lido:term>
+                                <lido:term xml:lang="en">hand-cart</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698594</lido:objectID>
+                                <lido:objectNote>Revue suisse de photographie / Société genevoise de photographie ... [et al.]</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698721</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1104A-2</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698721</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T14:35:44</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{AE2F3055-2B56-4B28-B327-69EB8FDD73C3}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/X-GkpJD5Q5cezmu8si1XtxIZFuk10bWL5AQalxfR0a4R6_R4dboBCQW-p15P5WPxDGppa6qSJhiTDu7ejb_5SsU_y91H=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/691511</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.691511</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een aantal onbekende vrouwen in klederdracht op het strand</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Erwartung</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-5-172</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>101</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>201</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1897</lido:earliestDate>
+                                <lido:latestDate>1902</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                                <lido:term lido:pref="alternative">31D15</lido:term>
+                                <lido:term xml:lang="en">adult woman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H133</lido:term>
+                                <lido:term xml:lang="en">beach</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41D3</lido:conceptID>
+                                <lido:term lido:pref="alternative">41D3</lido:term>
+                                <lido:term xml:lang="en">folk costume, regional costume</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689817</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">691511</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-5-172</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.691511</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T14:12:50</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{37A19E1E-478C-4ADF-8F9D-E402D02FA150}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689355</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689355</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een kanaal in Venetië met gondels</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Bit of Venice</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-197</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>180</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>123</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.5204</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Venice</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Venetië</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H224</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H224</lido:term>
+                                <lido:term xml:lang="en">small canal, ditch</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C23231</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C23231</lido:term>
+                                <lido:term xml:lang="en">gondola</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C112</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C112</lido:term>
+                                <lido:term xml:lang="en">bridge</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.5204</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="en">Venice</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">Venetië</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689355</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-197</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689355</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:06:35</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{859D6BAC-AE69-4B8B-B507-BE10992474FE}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/FXu6DvKT6xz5y5xshkrDOTIZrdqCwbbxCJ6mzYlehV3QGjIlj2d9BMS59WwA9cbMiCRpeHf9TE0GfAYQjuOeRf2UwcI=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689346</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689346</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een besneeuwde straat in New York met paardenkarren</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Winter 5th avenue N.Y.</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-192</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>179</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>140</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C144</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C144</lido:term>
+                                <lido:term xml:lang="en">four-wheeled, animal-drawn vehicle, e.g.: cab, carriage, coach</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/26D1</lido:conceptID>
+                                <lido:term lido:pref="alternative">26D1</lido:term>
+                                <lido:term xml:lang="en">snow</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689346</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-192</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689346</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:06:33</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{63904738-45EC-453E-8275-23745703CAA1}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ufM_ka7zkD-be50_naNcIuT6oM3KBh_aRhUxYEedXsz38V8Y4H8Z5UfudZf5AZSIeas2VX71J9800pE_zMzHpEjcoQ=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689338</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689338</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op boten die aankomen aan de kust en een groep mensen</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The inkoming boats</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-191</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>63</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>179</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H13</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H13</lido:term>
+                                <lido:term xml:lang="en">coast</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C24</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C24</lido:term>
+                                <lido:term xml:lang="en">sailing-ship, sailing-boat</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689338</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-191</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689338</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:06:33</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{4497D343-5905-4361-823E-9E1395C60A8A}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/db_FrOU3IUod8xxH-wsU_E02v74IDK1dSpkEUtCGvXxnqeubPUHgOp5t7GGECs3F38M0YMUZig4tW87jtuCncO82w-nT=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689335</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689335</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een weg met koeien langs het water</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">A decorative panel</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-190</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>88</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>145</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/47I2112</lido:conceptID>
+                                <lido:term lido:pref="alternative">47I2112</lido:term>
+                                <lido:term xml:lang="en">cow</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C11</lido:conceptID>
+                                <lido:term lido:pref="alternative">46C11</lido:term>
+                                <lido:term xml:lang="en">road, path</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689335</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-190</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689335</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:06:32</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9A0C7995-791A-4ED8-BF55-266E95FBB9E3}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/z_XDy10m1nLG2NnS2wVFuTx3EHgKU_2OrZQOF5DZTYgaPIROq8evudhJT6fKdUU2of_ZbgURTlPRoexN9sSEzbj4XR4=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689332</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689332</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een straat met mensen met paraplu's</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Wet day on the boulevard</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-189</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>77</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>145</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I141</lido:term>
+                                <lido:term xml:lang="en">street</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41D2631</lido:conceptID>
+                                <lido:term lido:pref="alternative">41D2631</lido:term>
+                                <lido:term xml:lang="en">umbrella</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689332</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-189</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689332</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-07-24T16:40:32</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{3F655D67-70AC-4A89-ADEF-732E9717DAFB}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/nu2NXR6UK6p2zb07uc6b_WCqZXgeXQAt3tm9F1nXwG8DojU79p2ySrxAGeGS6LDIhw_bfKkcig2LlOSA5KxSD14NKje8=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689331</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689331</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een onbekende vrouw in een weiland</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR/ &amp;Co</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-188</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>139</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>180</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H17</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H17</lido:term>
+                                <lido:term xml:lang="en">meadow, pasture</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                                <lido:term lido:pref="alternative">31D15</lido:term>
+                                <lido:term xml:lang="en">adult woman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689331</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-188</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689331</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:06:31</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{400B3461-7172-411A-936F-98F0D4187C67}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/VG5BPj8wGZGyBFVAuaJu483VFyUCKzwSM-jHox85kdsvIwlT7tsGrnMeh-iiAy_xtszBKIrjF1MkETwhcVlFjrL9KVo=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/688876</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688876</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op twee onbekende vrouwen die over het strand wandelen met op de achtergrond een kerk</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Scurrying Home</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>[...]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                    <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Nachdruck verboten</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-90</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>199</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>149</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H133</lido:term>
+                                <lido:term xml:lang="en">beach</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/11Q712</lido:conceptID>
+                                <lido:term lido:pref="alternative">11Q712</lido:term>
+                                <lido:term xml:lang="en">church (exterior)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">688876</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-90</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.688876</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:04:45</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{10AD47B7-D7BB-4629-A2F3-0BEF9A94154B}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/F93s86Uho5Xf0imKm_z7yEalNTam1LAOS4lvnpbVGCt3Ygi8p1Qm4ZyqNI72hrRHq-jEUMRkF5tuAr9eh_JdNH7iQcTZ=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/688805</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688805</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een leeg plein met een aantal bomen</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Reflections, Night</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:inscriptionsWrap>
+                    <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>Coils(...)</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                            <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                    </lido:inscriptions>
+                </lido:inscriptionsWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-81</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>110</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>145</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1895</lido:earliestDate>
+                                <lido:latestDate>1900</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                        <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25G3</lido:conceptID>
+                                <lido:term lido:pref="alternative">25G3</lido:term>
+                                <lido:term xml:lang="en">trees</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I144</lido:conceptID>
+                                <lido:term lido:pref="alternative">25I144</lido:term>
+                                <lido:term xml:lang="en">square, place, circus, etc.</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                                <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">688805</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-81</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.688805</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T16:04:24</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0880B696-4D84-4FB3-A1C9-9A475C5BB2FF}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/I_gQ3DqhK2rIX__KkkDEID3Ac7RpMXkrbCjq9FRgN8Es2_NxNFj8RT2QsKMQeo_8u6fuapYVf-aDIiU31wzMTcMMEmk=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/683254</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.683254</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                    </lido:objectWorkType>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="en">Market girl, Ballagio, Italy</lido:appellationValue>
+                        <lido:appellationValue xml:lang="nl">Portret van een meisje met een rieten mand op de rug</lido:appellationValue>
+                    </lido:titleSet>
+                    <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Market girl, Ballagio, Italy</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-964-21</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>154</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>93</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1888</lido:earliestDate>
+                                <lido:latestDate>1893</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.92663</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Bellagio (Italië)</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                                    <lido:term xml:lang="nl">autotypie</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Weeks Engraving Co., The</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                                    <lido:term xml:lang="nl">clichémaker</lido:term>
+                                </lido:roleActor>
+                                <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                                <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>2001</lido:earliestDate>
+                                <lido:latestDate>2001</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                            <lido:term xml:lang="en">purchase</lido:term>
+                            <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D11222</lido:conceptID>
+                                <lido:term lido:pref="alternative">31D11222</lido:term>
+                                <lido:term xml:lang="en">girl (child between toddler and youth)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41A7751</lido:conceptID>
+                                <lido:term lido:pref="alternative">41A7751</lido:term>
+                                <lido:term xml:lang="en">container made of plant material other than wood: basket</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.683203</lido:objectID>
+                                <lido:objectNote>The international annual of Anthony's photographic bulletin</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">683254</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-964-21</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.683254</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2019-05-09T14:00:15</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9094FA97-A028-4484-9CBB-8049BF18FE97}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ZhF-G2JvA2N4424-RktZPri2nZxNn-P8FbmIUr-qUMUY7YMHwLMcmuWJCFpQtIGwIlCDR1Gm_Om3WEhOpwdEi1HFDA=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/54448</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.54448</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="en">Scurrying Home</lido:appellationValue>
+                        <lido:appellationValue xml:lang="nl">Vissersvrouwen te Katwijk</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-00-44</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectDescriptionWrap>
+                    <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Scurrying home in Photograms 1895.</lido:descriptiveNoteValue>
+                    </lido:objectDescriptionSet>
+                </lido:objectDescriptionWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>190</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>157</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>485</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>370</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1897</lido:earliestDate>
+                                <lido:latestDate>1897</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                            <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300014224</lido:conceptID>
+                                    <lido:term xml:lang="en">cardboard</lido:term>
+                                    <lido:term xml:lang="nl">karton</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16582</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Photographische Gesellschaft Berlin</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1989</lido:earliestDate>
+                                <lido:latestDate>1989</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.13</lido:conceptID>
+                            <lido:term xml:lang="en">gift</lido:term>
+                            <lido:term xml:lang="nl">schenking</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/11Q712</lido:conceptID>
+                                <lido:term lido:pref="alternative">11Q712</lido:term>
+                                <lido:term xml:lang="en">church (exterior)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61E(Katwijk)</lido:conceptID>
+                                <lido:term lido:pref="alternative">61E(Katwijk)</lido:term>
+                                <lido:term xml:lang="en">names of cities and villages (Katwijk)</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C128</lido:conceptID>
+                                <lido:term lido:pref="alternative">43C128</lido:term>
+                                <lido:term xml:lang="en">fisherman</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectConcept>
+                                <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H1321</lido:conceptID>
+                                <lido:term lido:pref="alternative">25H1321</lido:term>
+                                <lido:term xml:lang="en">dunes (sea not visible); in the dunes</lido:term>
+                            </lido:subjectConcept>
+                        </lido:subject>
+                    </lido:subjectSet>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/149108</lido:objectID>
+                                <lido:objectNote>Der weite Blick : Landschaften der Haager Schule aus dem Rijksmuseum</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/154531</lido:objectID>
+                                <lido:objectNote>Until they meet the greyer sky : Buitenlandse fotografen in Nederland in de late 19de en het begin van de 20ste eeuw</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                    <lido:creditLine xml:lang="en">Gift of the heirs of C.J.J.G. Vosmaer, Leiden</lido:creditLine>
+                    <lido:creditLine xml:lang="nl">Schenking van de erven van de heer C.J.J.G. Vosmaer, Leiden</lido:creditLine>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">54448</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-00-44</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.54448</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2018-02-15T10:11:56</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{148B1FB8-588A-4D07-ACE7-751A1D85CA1D}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/Z6Re_0jCKlXtxR9QTbAAlc6bRV8Um2UFk7E_iu0WVBecdet258g8W7tlPLjC_HtTwMRVxAY0_9kaVwG5ASX8OJN6dbI=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+    <lido:lido>
+        <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/456781</lido:lidoRecID>
+        <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.456781</lido:objectPublishedID>
+        <lido:descriptiveMetadata xml:lang="en">
+            <lido:objectClassificationWrap>
+                <lido:objectWorkTypeWrap>
+                    <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                    </lido:objectWorkType>
+                </lido:objectWorkTypeWrap>
+                <lido:classificationWrap>
+                    <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                    </lido:classification>
+                </lido:classificationWrap>
+            </lido:objectClassificationWrap>
+            <lido:objectIdentificationWrap>
+                <lido:titleWrap>
+                    <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Netzflickerin (Mending Nets), Katwijk 1894</lido:appellationValue>
+                    </lido:titleSet>
+                </lido:titleWrap>
+                <lido:repositoryWrap>
+                    <lido:repositorySet>
+                        <lido:repositoryName>
+                            <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                            <lido:legalBodyName>
+                                <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                            </lido:legalBodyName>
+                            <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">BI-F-B0447-2-1-5</lido:workID>
+                        <lido:repositoryLocation>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                            <lido:namePlaceSet>
+                                <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                            </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                    </lido:repositorySet>
+                </lido:repositoryWrap>
+                <lido:objectDescriptionWrap>
+                    <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Foto komt uit Die Kunst in der Photographie jrg. 2 (1898) 1, pl. 5.</lido:descriptiveNoteValue>
+                    </lido:objectDescriptionSet>
+                </lido:objectDescriptionWrap>
+                <lido:objectMeasurementsWrap>
+                    <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">height</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>260</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:measurementsSet>
+                                <lido:measurementType xml:lang="en">width</lido:measurementType>
+                                <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                                <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                                <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                                <lido:measurementValue>348</lido:measurementValue>
+                            </lido:measurementsSet>
+                            <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                    </lido:objectMeasurementsSet>
+                </lido:objectMeasurementsWrap>
+            </lido:objectIdentificationWrap>
+            <lido:eventWrap>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Amerikaans</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                        <lido:latestDate>1946-07-13</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                                    <lido:term xml:lang="nl">fotograaf</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1894</lido:earliestDate>
+                                <lido:latestDate>1898</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58618</lido:conceptID>
+                            <lido:term xml:lang="en">third quarter 19th century</lido:term>
+                            <lido:term xml:lang="nl">derde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                                    <lido:term xml:lang="en">paper</lido:term>
+                                    <lido:term xml:lang="nl">papier</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300015012</lido:conceptID>
+                                    <lido:term xml:lang="en">ink</lido:term>
+                                    <lido:term xml:lang="nl">inkt</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                            <lido:materialsTech>
+                                <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                                    <lido:term xml:lang="nl">heliogravure</lido:term>
+                                </lido:termMaterialsTech>
+                            </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                            <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109394</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Büxenstein &amp; Comp., Georg</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                                    <lido:term xml:lang="en">printer</lido:term>
+                                    <lido:term xml:lang="nl">drukker</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                            <lido:term xml:lang="en">Publication (Event)</lido:term>
+                            <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                            <lido:actorInRole>
+                                <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                                    <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109393</lido:actorID>
+                                    <lido:nameActorSet>
+                                        <lido:appellationValue xml:lang="nl">Goerke, Franz</lido:appellationValue>
+                                    </lido:nameActorSet>
+                                    <lido:nationalityActor>
+                                        <lido:term xml:lang="nl">Duits</lido:term>
+                                    </lido:nationalityActor>
+                                    <lido:vitalDatesActor>
+                                        <lido:earliestDate>1856-11-14</lido:earliestDate>
+                                        <lido:latestDate>1931-05-14</lido:latestDate>
+                                    </lido:vitalDatesActor>
+                                </lido:actor>
+                                <lido:roleActor>
+                                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                                    <lido:term xml:lang="en">publisher</lido:term>
+                                    <lido:term xml:lang="nl">uitgever</lido:term>
+                                </lido:roleActor>
+                            </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                            <lido:place>
+                                <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                                <lido:namePlaceSet>
+                                    <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                                    <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                                </lido:namePlaceSet>
+                            </lido:place>
+                        </lido:eventPlace>
+                    </lido:event>
+                </lido:eventSet>
+                <lido:eventSet>
+                    <lido:event>
+                        <lido:eventType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                            <lido:term xml:lang="en">Acquisition</lido:term>
+                            <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                            <lido:date>
+                                <lido:earliestDate>1898</lido:earliestDate>
+                                <lido:latestDate>1898</lido:latestDate>
+                            </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                            <lido:term xml:lang="en">transfer</lido:term>
+                            <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                    </lido:event>
+                </lido:eventSet>
+            </lido:eventWrap>
+            <lido:objectRelationWrap>
+                <lido:subjectWrap>
+                    <lido:subjectSet>
+                        <lido:subject>
+                            <lido:subjectPlace>
+                                <lido:place>
+                                    <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                                    <lido:namePlaceSet>
+                                        <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                                    </lido:namePlaceSet>
+                                </lido:place>
+                            </lido:subjectPlace>
+                        </lido:subject>
+                    </lido:subjectSet>
+                </lido:subjectWrap>
+                <lido:relatedWorksWrap>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/154531</lido:objectID>
+                                <lido:objectNote>Until they meet the greyer sky : Buitenlandse fotografen in Nederland in de late 19de en het begin van de 20ste eeuw</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                    <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                            <lido:object>
+                                <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/149108</lido:objectID>
+                                <lido:objectNote>Der weite Blick : Landschaften der Haager Schule aus dem Rijksmuseum</lido:objectNote>
+                            </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                    </lido:relatedWorkSet>
+                </lido:relatedWorksWrap>
+            </lido:objectRelationWrap>
+        </lido:descriptiveMetadata>
+        <lido:administrativeMetadata xml:lang="en">
+            <lido:rightsWorkWrap>
+                <lido:rightsWorkSet>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                    </lido:rightsType>
+                </lido:rightsWorkSet>
+            </lido:rightsWorkWrap>
+            <lido:recordWrap>
+                <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">456781</lido:recordID>
+                <lido:recordType>
+                    <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                    <lido:term>Item-level record</lido:term>
+                </lido:recordType>
+                <lido:recordSource>
+                    <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                    <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                    </lido:legalBodyName>
+                    <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                </lido:recordSource>
+                <lido:recordRights>
+                    <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                    </lido:rightsType>
+                    <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:rightsHolder>
+                    <lido:creditLine>Rijksmuseum</lido:creditLine>
+                </lido:recordRights>
+                <lido:recordInfoSet>
+                    <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:BI-F-B0447-2-1-5</lido:recordInfoID>
+                    <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.456781</lido:recordInfoLink>
+                    <lido:recordMetadataDate>2016-12-28T14:14:18</lido:recordMetadataDate>
+                </lido:recordInfoSet>
+            </lido:recordWrap>
+            <lido:resourceWrap>
+                <lido:resourceSet>
+                    <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{06FD28A8-ADE1-4F85-B08F-50DBD269A791}</lido:resourceID>
+                    <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ymK9QpdJQa2jkTVCBwYZ0Rt-2h8P_BZsngPuDZE2al3Cafa8ZJDSDKZh1tTRiSsGwPac5JjROqy51lGSiqFcD1E2Fjg=s0</lido:linkResource>
+                    </lido:resourceRepresentation>
+                    <lido:resourceDescription lido:type="download"/>
+                    <lido:rightsResource>
+                        <lido:rightsType>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                            <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:rightsResource>
+                </lido:resourceSet>
+            </lido:resourceWrap>
+        </lido:administrativeMetadata>
+    </lido:lido>
+</lido:lidoWrap>

--- a/data/rma/lido/oai/BI-F-B0447-2-1-5.xml
+++ b/data/rma/lido/oai/BI-F-B0447-2-1-5.xml
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:BI-F-B0447-2-1-5" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:BI-F-B0447-2-1-5</identifier>
+        <datestamp>2016-12-28T13:14:18Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:BI-F-B0447-2-1-5</identifier>
+            <datestamp>2016-12-28T14:14:18Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/456781</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.456781</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Netzflickerin (Mending Nets), Katwijk 1894</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">BI-F-B0447-2-1-5</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectDescriptionWrap>
+                      <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Foto komt uit Die Kunst in der Photographie jrg. 2 (1898) 1, pl. 5.</lido:descriptiveNoteValue>
+                      </lido:objectDescriptionSet>
+                    </lido:objectDescriptionWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>260</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>348</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1894</lido:earliestDate>
+                            <lido:latestDate>1898</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58618</lido:conceptID>
+                          <lido:term xml:lang="en">third quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">derde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300015012</lido:conceptID>
+                              <lido:term xml:lang="en">ink</lido:term>
+                              <lido:term xml:lang="nl">inkt</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109394</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Büxenstein &amp; Comp., Georg</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109393</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Goerke, Franz</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1856-11-14</lido:earliestDate>
+                                <lido:latestDate>1931-05-14</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1898</lido:earliestDate>
+                            <lido:latestDate>1898</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/154531</lido:objectID>
+                            <lido:objectNote>Until they meet the greyer sky : Buitenlandse fotografen in Nederland in de late 19de en het begin van de 20ste eeuw</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/149108</lido:objectID>
+                            <lido:objectNote>Der weite Blick : Landschaften der Haager Schule aus dem Rijksmuseum</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">456781</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:BI-F-B0447-2-1-5</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.456781</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2016-12-28T14:14:18</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{06FD28A8-ADE1-4F85-B08F-50DBD269A791}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ymK9QpdJQa2jkTVCBwYZ0Rt-2h8P_BZsngPuDZE2al3Cafa8ZJDSDKZh1tTRiSsGwPac5JjROqy51lGSiqFcD1E2Fjg=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-00-44.xml
+++ b/data/rma/lido/oai/RP-F-00-44.xml
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-00-44" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-00-44</identifier>
+        <datestamp>2018-02-15T09:11:56Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-00-44</identifier>
+            <datestamp>2018-02-15T10:11:56Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/54448</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.54448</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="en">Scurrying Home</lido:appellationValue>
+                        <lido:appellationValue xml:lang="nl">Vissersvrouwen te Katwijk</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-00-44</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectDescriptionWrap>
+                      <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Scurrying home in Photograms 1895.</lido:descriptiveNoteValue>
+                      </lido:objectDescriptionSet>
+                    </lido:objectDescriptionWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>190</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>157</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>485</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>370</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1897</lido:earliestDate>
+                            <lido:latestDate>1897</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                          <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300014224</lido:conceptID>
+                              <lido:term xml:lang="en">cardboard</lido:term>
+                              <lido:term xml:lang="nl">karton</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16582</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Photographische Gesellschaft Berlin</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1989</lido:earliestDate>
+                            <lido:latestDate>1989</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.13</lido:conceptID>
+                          <lido:term xml:lang="en">gift</lido:term>
+                          <lido:term xml:lang="nl">schenking</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/11Q712</lido:conceptID>
+                            <lido:term lido:pref="alternative">11Q712</lido:term>
+                            <lido:term xml:lang="en">church (exterior)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61E(Katwijk)</lido:conceptID>
+                            <lido:term lido:pref="alternative">61E(Katwijk)</lido:term>
+                            <lido:term xml:lang="en">names of cities and villages (Katwijk)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C128</lido:conceptID>
+                            <lido:term lido:pref="alternative">43C128</lido:term>
+                            <lido:term xml:lang="en">fisherman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H1321</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H1321</lido:term>
+                            <lido:term xml:lang="en">dunes (sea not visible); in the dunes</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.38583</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="nl">Katwijk</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/149108</lido:objectID>
+                            <lido:objectNote>Der weite Blick : Landschaften der Haager Schule aus dem Rijksmuseum</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/154531</lido:objectID>
+                            <lido:objectNote>Until they meet the greyer sky : Buitenlandse fotografen in Nederland in de late 19de en het begin van de 20ste eeuw</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Gift of the heirs of C.J.J.G. Vosmaer, Leiden</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Schenking van de erven van de heer C.J.J.G. Vosmaer, Leiden</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">54448</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-00-44</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.54448</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-02-15T10:11:56</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{148B1FB8-588A-4D07-ACE7-751A1D85CA1D}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/Z6Re_0jCKlXtxR9QTbAAlc6bRV8Um2UFk7E_iu0WVBecdet258g8W7tlPLjC_HtTwMRVxAY0_9kaVwG5ASX8OJN6dbI=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1104A-2.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1104A-2.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1104A-2" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1104A-2</identifier>
+        <datestamp>2019-05-09T12:35:44Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1104A-2</identifier>
+            <datestamp>2019-05-09T14:35:44Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698721</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698721</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Onbekende mannen op een kar met vaten met vermoedelijk Chanti</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Chianti</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1104A-2</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>146</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>113</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.55993</lido:conceptID>
+                              <lido:term xml:lang="en">maker</lido:term>
+                              <lido:term xml:lang="nl">vervaardiger</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1889</lido:earliestDate>
+                            <lido:latestDate>1894</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Photochrome Engraving Co.</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.55993</lido:conceptID>
+                              <lido:term xml:lang="en">maker</lido:term>
+                              <lido:term xml:lang="nl">vervaardiger</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61B2</lido:conceptID>
+                            <lido:term lido:pref="alternative">61B2</lido:term>
+                            <lido:term xml:lang="en">historical persons</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C123</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C123</lido:term>
+                            <lido:term xml:lang="en">hand-cart</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698594</lido:objectID>
+                            <lido:objectNote>Revue suisse de photographie / Société genevoise de photographie ... [et al.]</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698721</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1104A-2</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698721</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T14:35:44</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{AE2F3055-2B56-4B28-B327-69EB8FDD73C3}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/X-GkpJD5Q5cezmu8si1XtxIZFuk10bWL5AQalxfR0a4R6_R4dboBCQW-p15P5WPxDGppa6qSJhiTDu7ejb_5SsU_y91H=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1184B-220.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1184B-220.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1184B-220" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1184B-220</identifier>
+        <datestamp>2019-05-09T12:33:19Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1184B-220</identifier>
+            <datestamp>2019-05-09T14:33:19Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698107</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698107</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spoorlijnen met stoomtrein</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Hand of Man</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>BX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1184B-220</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>89</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>120</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1898</lido:earliestDate>
+                            <lido:latestDate>1903</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C1511</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C1511</lido:term>
+                            <lido:term xml:lang="en">railway, train</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.697238</lido:objectID>
+                            <lido:objectNote>Photographische Mittheilungen</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698107</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1184B-220</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698107</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T14:33:19</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{C6B665CE-AA19-49EC-B650-AD60FE197618}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/Bc9slaZnmqDKAwt2z5Vi4aX1zQBtu_2N3vQyZL25CvibKbbxAvmvbwPbBXQSVjcLYUyyzkm8BmpR9fgPgR0aT-S0cRU=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1184B-223.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1184B-223.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1184B-223" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1184B-223</identifier>
+        <datestamp>2019-05-09T12:33:22Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1184B-223</identifier>
+            <datestamp>2019-05-09T14:33:22Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/698117</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.698117</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van een onbekende vrouw</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>BX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1184B-223</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>139</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>80</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1898</lido:earliestDate>
+                            <lido:latestDate>1903</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2</lido:conceptID>
+                            <lido:term lido:pref="alternative">61BB2</lido:term>
+                            <lido:term xml:lang="en">historical persons - BB - woman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.697238</lido:objectID>
+                            <lido:objectNote>Photographische Mittheilungen</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">698117</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1184B-223</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.698117</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T14:33:22</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0E280B39-B49A-4774-9CBA-A952E5A894C7}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/aPMWpttxa6oUszGHrpIBxV7GABS0Jsdcrp6qcUiUe5VlUSuIyc-coxJ2612M81SlZod7pqJiJvw1fnnSBVt0no8i7Lw=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1187A-13.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1187A-13.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1187A-13" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1187A-13</identifier>
+        <datestamp>2019-05-09T14:13:30Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1187A-13</identifier>
+            <datestamp>2019-05-09T16:13:30Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/695950</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.695950</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Drietal boten worden opgewacht door een groep mensen op het strand</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Landing of the Boats</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1187A-13</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>76</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>205</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Photochrome Engraving Co.</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C24</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C24</lido:term>
+                            <lido:term xml:lang="en">sailing-ship, sailing-boat</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H133</lido:term>
+                            <lido:term xml:lang="en">beach</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.695912</lido:objectID>
+                            <lido:objectNote>Camera notes / The Camera Club of New York</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">695950</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1187A-13</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.695950</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:13:30</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{8B2D7D78-05AB-496B-8E12-AE14BF7337A0}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/lpja5XYhcLAGHqwvJnm5PFq5dT17JYcIdA43QYTAZZHOdFb9g8Hpdgm_1fpCdaWm4RBiCX_jt2mK6yg9JxR5ZWzq4pES=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1468-46.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1468-46.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1468-46" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1468-46</identifier>
+        <datestamp>2019-05-08T15:02:38Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1468-46</identifier>
+            <datestamp>2019-05-08T17:02:38Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/609302</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.609302</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Twee vrouwen op een strand</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Strassenklatsch</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1468-46</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>122</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>209</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1889</lido:earliestDate>
+                            <lido:latestDate>1899</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7000084</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Germany</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Duitsland</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.109394</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Büxenstein &amp; Comp., Georg</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.134385</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Becker, Julius</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H133</lido:term>
+                            <lido:term xml:lang="en">beach</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                            <lido:term lido:pref="alternative">31D15</lido:term>
+                            <lido:term xml:lang="en">adult woman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C21</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C21</lido:term>
+                            <lido:term xml:lang="en">ships (in general)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.609180</lido:objectID>
+                            <lido:objectNote>Die Kunst in der Photographie 1899</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">609302</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1468-46</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.609302</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-08T17:02:38</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{524DB0C4-402E-4147-A6CB-647F8F94E1A2}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/DsR_9CdDaMywuI7JqB-Pcuq0R_DPr-1bt0ald3iiT2B-g9yzuCux-JNRylt5Y8GRO2Tptj1Lglpw0HxbA--MMPOLAw=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1668-44.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1668-44.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1668-44" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-44</identifier>
+        <datestamp>2019-05-09T14:59:45Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-44</identifier>
+            <datestamp>2019-05-09T16:59:45Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718441</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718441</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht bij nacht</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. VIII.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Reflections night by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-44</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>109</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>142</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1900</lido:earliestDate>
+                            <lido:latestDate>1905</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.552983</lido:conceptID>
+                              <lido:term xml:lang="nl">tweekleurenautotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/23R14</lido:conceptID>
+                            <lido:term lido:pref="alternative">23R14</lido:term>
+                            <lido:term xml:lang="en">night</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                            <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718441</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-44</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718441</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:59:45</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{268B73D2-733D-4F7C-8483-0CE9F082DB7A}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1668-46.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1668-46.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1668-46" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-46</identifier>
+        <datestamp>2019-05-09T14:59:48Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-46</identifier>
+            <datestamp>2019-05-09T16:59:48Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718453</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718453</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spoorlijnen met stoomtrein</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. X.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>The hand of man by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-46</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>109</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>142</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1900</lido:earliestDate>
+                            <lido:latestDate>1905</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.552983</lido:conceptID>
+                              <lido:term xml:lang="nl">tweekleurenautotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C1511</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C1511</lido:term>
+                            <lido:term xml:lang="en">railway, train</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                            <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718453</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-46</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718453</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:59:48</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{B8AE2C1F-40D5-4E7A-A7F1-ABB3D224A500}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-1668-53.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-1668-53.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-1668-53" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-53</identifier>
+        <datestamp>2019-05-09T14:59:51Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-1668-53</identifier>
+            <datestamp>2019-05-09T16:59:51Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/718467</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718467</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Paardenrace</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>US. XVII.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Going to the post by Alfred Stieglitz</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-1668-53</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>129</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>119</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1900</lido:earliestDate>
+                            <lido:latestDate>1905</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C2121</lido:conceptID>
+                            <lido:term lido:pref="alternative">43C2121</lido:term>
+                            <lido:term xml:lang="en">horse-racing</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.718015</lido:objectID>
+                            <lido:objectNote>Art in photography : with selected examples of European and American work</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">718467</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-1668-53</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.718467</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:59:51</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{3930CEB1-5E55-4046-9738-F15E1BDBC605}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-964-21.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-964-21.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-964-21" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-964-21</identifier>
+        <datestamp>2019-05-09T12:00:15Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-964-21</identifier>
+            <datestamp>2019-05-09T14:00:15Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/683254</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.683254</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="en">Market girl, Ballagio, Italy</lido:appellationValue>
+                        <lido:appellationValue xml:lang="nl">Portret van een meisje met een rieten mand op de rug</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Market girl, Ballagio, Italy</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-964-21</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>154</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>93</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1888</lido:earliestDate>
+                            <lido:latestDate>1893</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.92663</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Bellagio (Italië)</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.0</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Weeks Engraving Co., The</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D11222</lido:conceptID>
+                            <lido:term lido:pref="alternative">31D11222</lido:term>
+                            <lido:term xml:lang="en">girl (child between toddler and youth)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41A7751</lido:conceptID>
+                            <lido:term lido:pref="alternative">41A7751</lido:term>
+                            <lido:term xml:lang="en">container made of plant material other than wood: basket</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.683203</lido:objectID>
+                            <lido:objectNote>The international annual of Anthony's photographic bulletin</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">683254</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-964-21</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.683254</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T14:00:15</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9094FA97-A028-4484-9CBB-8049BF18FE97}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ZhF-G2JvA2N4424-RktZPri2nZxNn-P8FbmIUr-qUMUY7YMHwLMcmuWJCFpQtIGwIlCDR1Gm_Om3WEhOpwdEi1HFDA=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-188.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-188.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-188" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-188</identifier>
+        <datestamp>2019-05-09T14:06:31Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-188</identifier>
+            <datestamp>2019-05-09T16:06:31Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689331</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689331</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een onbekende vrouw in een weiland</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR/ &amp;Co</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-188</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>139</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>180</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H17</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H17</lido:term>
+                            <lido:term xml:lang="en">meadow, pasture</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                            <lido:term lido:pref="alternative">31D15</lido:term>
+                            <lido:term xml:lang="en">adult woman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689331</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-188</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689331</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:06:31</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{400B3461-7172-411A-936F-98F0D4187C67}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/VG5BPj8wGZGyBFVAuaJu483VFyUCKzwSM-jHox85kdsvIwlT7tsGrnMeh-iiAy_xtszBKIrjF1MkETwhcVlFjrL9KVo=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-189.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-189.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-189" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-189</identifier>
+        <datestamp>2019-07-24T14:40:32Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-189</identifier>
+            <datestamp>2019-07-24T16:40:32Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689332</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689332</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een straat met mensen met paraplu's</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Wet day on the boulevard</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-189</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>77</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>145</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41D2631</lido:conceptID>
+                            <lido:term lido:pref="alternative">41D2631</lido:term>
+                            <lido:term xml:lang="en">umbrella</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689332</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-189</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689332</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-07-24T16:40:32</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{3F655D67-70AC-4A89-ADEF-732E9717DAFB}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/nu2NXR6UK6p2zb07uc6b_WCqZXgeXQAt3tm9F1nXwG8DojU79p2ySrxAGeGS6LDIhw_bfKkcig2LlOSA5KxSD14NKje8=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-190.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-190.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-190" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-190</identifier>
+        <datestamp>2019-05-09T14:06:32Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-190</identifier>
+            <datestamp>2019-05-09T16:06:32Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689335</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689335</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een weg met koeien langs het water</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">A decorative panel</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-190</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>88</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>145</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/47I2112</lido:conceptID>
+                            <lido:term lido:pref="alternative">47I2112</lido:term>
+                            <lido:term xml:lang="en">cow</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C11</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C11</lido:term>
+                            <lido:term xml:lang="en">road, path</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689335</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-190</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689335</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:06:32</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9A0C7995-791A-4ED8-BF55-266E95FBB9E3}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/z_XDy10m1nLG2NnS2wVFuTx3EHgKU_2OrZQOF5DZTYgaPIROq8evudhJT6fKdUU2of_ZbgURTlPRoexN9sSEzbj4XR4=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-191.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-191.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-191" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-191</identifier>
+        <datestamp>2019-05-09T14:06:33Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-191</identifier>
+            <datestamp>2019-05-09T16:06:33Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689338</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689338</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op boten die aankomen aan de kust en een groep mensen</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The inkoming boats</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-191</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>63</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>179</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H13</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H13</lido:term>
+                            <lido:term xml:lang="en">coast</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C24</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C24</lido:term>
+                            <lido:term xml:lang="en">sailing-ship, sailing-boat</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689338</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-191</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689338</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:06:33</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{4497D343-5905-4361-823E-9E1395C60A8A}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/db_FrOU3IUod8xxH-wsU_E02v74IDK1dSpkEUtCGvXxnqeubPUHgOp5t7GGECs3F38M0YMUZig4tW87jtuCncO82w-nT=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-192.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-192.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-192" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-192</identifier>
+        <datestamp>2019-05-09T14:06:33Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-192</identifier>
+            <datestamp>2019-05-09T16:06:33Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689346</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689346</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een besneeuwde straat in New York met paardenkarren</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Winter 5th avenue N.Y.</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-192</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>179</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>140</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C144</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C144</lido:term>
+                            <lido:term xml:lang="en">four-wheeled, animal-drawn vehicle, e.g.: cab, carriage, coach</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/26D1</lido:conceptID>
+                            <lido:term lido:pref="alternative">26D1</lido:term>
+                            <lido:term xml:lang="en">snow</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689346</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-192</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689346</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:06:33</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{63904738-45EC-453E-8275-23745703CAA1}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/ufM_ka7zkD-be50_naNcIuT6oM3KBh_aRhUxYEedXsz38V8Y4H8Z5UfudZf5AZSIeas2VX71J9800pE_zMzHpEjcoQ=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-197.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-197.xml
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-197" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-197</identifier>
+        <datestamp>2019-05-09T14:06:35Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-197</identifier>
+            <datestamp>2019-05-09T16:06:35Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/689355</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689355</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een kanaal in Venetië met gondels</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Bit of Venice</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>MR&amp;C</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-197</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>180</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>123</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.5204</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Venice</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Venetië</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.18548</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Meisenbach, Riffarth &amp; Co</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Duits</lido:term>
+                              </lido:nationalityActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">possibly</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">mogelijk</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.24419</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Berlin</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Berlijn</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H224</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H224</lido:term>
+                            <lido:term xml:lang="en">small canal, ditch</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C23231</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C23231</lido:term>
+                            <lido:term xml:lang="en">gondola</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C112</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C112</lido:term>
+                            <lido:term xml:lang="en">bridge</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.5204</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">Venice</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">Venetië</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">689355</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-197</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.689355</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:06:35</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{859D6BAC-AE69-4B8B-B507-BE10992474FE}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/FXu6DvKT6xz5y5xshkrDOTIZrdqCwbbxCJ6mzYlehV3QGjIlj2d9BMS59WwA9cbMiCRpeHf9TE0GfAYQjuOeRf2UwcI=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-81.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-81.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-81" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-81</identifier>
+        <datestamp>2019-05-09T14:04:24Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-81</identifier>
+            <datestamp>2019-05-09T16:04:24Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/688805</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688805</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een leeg plein met een aantal bomen</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Reflections, Night</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>Coils(...)</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-81</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>110</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>145</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25G3</lido:conceptID>
+                            <lido:term lido:pref="alternative">25G3</lido:term>
+                            <lido:term xml:lang="en">trees</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I144</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I144</lido:term>
+                            <lido:term xml:lang="en">square, place, circus, etc.</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">688805</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-81</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.688805</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:04:24</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0880B696-4D84-4FB3-A1C9-9A475C5BB2FF}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/I_gQ3DqhK2rIX__KkkDEID3Ac7RpMXkrbCjq9FRgN8Es2_NxNFj8RT2QsKMQeo_8u6fuapYVf-aDIiU31wzMTcMMEmk=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-3-90.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-3-90.xml
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-3-90" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-90</identifier>
+        <datestamp>2019-05-09T14:04:45Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-3-90</identifier>
+            <datestamp>2019-05-09T16:04:45Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/688876</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688876</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op twee onbekende vrouwen die over het strand wandelen met op de achtergrond een kerk</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Scurrying Home</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="monogram">
+                        <lido:inscriptionTranscription>[...]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - afgedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="inscription">
+                        <lido:inscriptionTranscription>Nachdruck verboten</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-3-90</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>199</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>149</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1895</lido:earliestDate>
+                            <lido:latestDate>1900</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64482</lido:conceptID>
+                              <lido:term xml:lang="nl">autotypie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.21</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">unknown</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">onbekend</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.51371</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="nl">Halle an der Saale</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H133</lido:term>
+                            <lido:term xml:lang="en">beach</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/11Q712</lido:conceptID>
+                            <lido:term lido:pref="alternative">11Q712</lido:term>
+                            <lido:term xml:lang="en">church (exterior)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.688341</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">688876</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-3-90</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.688876</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T16:04:45</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{10AD47B7-D7BB-4629-A2F3-0BEF9A94154B}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/F93s86Uho5Xf0imKm_z7yEalNTam1LAOS4lvnpbVGCt3Ygi8p1Qm4ZyqNI72hrRHq-jEUMRkF5tuAr9eh_JdNH7iQcTZ=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2001-7-968-5-172.xml
+++ b/data/rma/lido/oai/RP-F-2001-7-968-5-172.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2001-7-968-5-172" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-5-172</identifier>
+        <datestamp>2019-05-09T12:12:50Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2001-7-968-5-172</identifier>
+            <datestamp>2019-05-09T14:12:50Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/691511</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.691511</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.556654</lido:conceptID>
+                        <lido:term xml:lang="en">photomechanical print</lido:term>
+                        <lido:term xml:lang="nl">fotomechanische afdruk</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://vocab.getty.edu/page/aat/300194222</lido:conceptID>
+                        <lido:term xml:lang="nl">bladzijde</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">fotografisch geïllustreerde boeken</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op een aantal onbekende vrouwen in klederdracht op het strand</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Erwartung</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2001-7-968-5-172</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>101</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>201</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">prent</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1897</lido:earliestDate>
+                            <lido:latestDate>1902</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.54</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="en">anonymous</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">anoniem</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.557205</lido:conceptID>
+                              <lido:term xml:lang="nl">clichémaker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.138423</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Wilhelm Knapp Verlag</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2001</lido:earliestDate>
+                            <lido:latestDate>2001</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/31D15</lido:conceptID>
+                            <lido:term lido:pref="alternative">31D15</lido:term>
+                            <lido:term xml:lang="en">adult woman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25H133</lido:conceptID>
+                            <lido:term lido:pref="alternative">25H133</lido:term>
+                            <lido:term xml:lang="en">beach</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41D3</lido:conceptID>
+                            <lido:term lido:pref="alternative">41D3</lido:term>
+                            <lido:term xml:lang="en">folk costume, regional costume</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.689817</lido:objectID>
+                            <lido:objectNote>Photographische Rundschau : Zeitschrift für Freunde der Photographie</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46i_forms_part_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the Mondriaan Stichting, the Prins Bernhard Cultuurfonds, the VSBfonds, the Paul Huf Fonds/Rijksmuseum Fonds and the Egbert Kunstfonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de Mondriaan Stichting, het Prins Bernhard Cultuurfonds, het VSBfonds, het Paul Huf Fonds/Rijksmuseum Fonds en het Egbert Kunstfonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">691511</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2001-7-968-5-172</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.691511</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-05-09T14:12:50</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{37A19E1E-478C-4ADF-8F9D-E402D02FA150}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-218.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-218.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-218" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-218</identifier>
+        <datestamp>2018-12-07T14:51:39Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-218</identifier>
+            <datestamp>2018-12-07T15:51:39Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434488</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434488</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Stadsgezicht van New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The City of Ambition</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 9584 [?] -7 [?] en doorgestreept: AS 9582-2</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 70767 [?] (A)</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-218</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>223</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>169</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>303</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>209</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1911</lido:earliestDate>
+                            <lido:latestDate>1911</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I1</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I1</lido:term>
+                            <lido:term xml:lang="en">city-view in general; 'veduta'</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434488</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-218</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434488</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{CFC2EB96-BBF6-4DE4-B074-ADDFCE8C14B7}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/qnWIOVkOWxPwabnxjCSjjDrYbAgD7GsJmWVVLuxcALW3QnZlALUlivq5Ux24mKcXsKewXr3CMyfLyIUjPP15IaqwTD8=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-220.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-220.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-220" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-220</identifier>
+        <datestamp>2018-12-07T14:51:39Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-220</identifier>
+            <datestamp>2018-12-07T15:51:39Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434486</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434486</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Street - Design for a Poster</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>e [??] W [?]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-220</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>176</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>134</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>304</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>211</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1903</lido:earliestDate>
+                            <lido:latestDate>1903</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.64336</lido:conceptID>
+                          <lido:term xml:lang="en">third quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">derde kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434486</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-220</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434486</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{77E77CE8-ADAE-47FC-8534-4BEDD1E8C94B}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/SHRuCzl7fdijYP4FtyYJzs7wR4hA_saEc5umJ2AhBYs7OiTSba7G8Y6wwnyuLOvNjEkIi-BS7NsQxJ5vMcf15_Pd_O4=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-221.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-221.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-221" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-221</identifier>
+        <datestamp>2018-12-07T14:51:39Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-221</identifier>
+            <datestamp>2018-12-07T15:51:39Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434487</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434487</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Op de renbaan</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Going to the Start</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-221</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>213</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>190</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>234</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>209</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1904</lido:earliestDate>
+                            <lido:latestDate>1904</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/43C21213</lido:conceptID>
+                            <lido:term lido:pref="alternative">43C21213</lido:term>
+                            <lido:term xml:lang="en">race-track</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434487</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-221</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434487</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:39</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{D53356B6-8857-4BAD-9419-B8C25A6E297A}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/q2wVqzLZxVEWaSOZCIWSptsPFRzsroF0Hj-VI-D3lKW4lppQLGp108mCi4dtn70u06LvzFfMKOSxaCDLtdLUHq92RFQ=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-222.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-222.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-222" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-222</identifier>
+        <datestamp>2018-12-07T14:51:40Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-222</identifier>
+            <datestamp>2018-12-07T15:51:40Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434489</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434489</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in Parijs</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">A Snapshot; Paris</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-222</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>137</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>174</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>281</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>200</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1911</lido:earliestDate>
+                            <lido:latestDate>1911</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434489</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-222</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434489</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:40</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{317E10B2-4E81-4A7C-9397-FC57DC504AD7}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/HfXSuUJsY501-xyRddjwayDpIsu6mVLS9JZggseqNT1cfSog8HqagexXt8a3-7qPSDgBJzhwsYsxyl9LwE1FfFQkAg=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-223.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-223.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-223" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-223</identifier>
+        <datestamp>2018-12-07T14:51:40Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-223</identifier>
+            <datestamp>2018-12-07T15:51:40Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434490</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434490</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op de rivier de Hudson en op New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The City Across the River</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>36:7</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-223</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>200</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>160</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>300</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>210</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1910</lido:earliestDate>
+                            <lido:latestDate>1910</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I1</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I1</lido:term>
+                            <lido:term xml:lang="en">city-view in general; 'veduta'</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.98448</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="nl">Hudson</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434490</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-223</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434490</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:40</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{F84E541A-7B58-415A-882C-33A11138AC41}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/mtvYC1aURZKe7hY4mP9Ad8OHHG0erKOduSGp1KCm1NIMSB6SxzeD4jdKAJY436FJx27iTiV5OhSxICGBSqo_PGD-bX4=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-224.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-224.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-224" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-224</identifier>
+        <datestamp>2018-12-07T14:51:41Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-224</identifier>
+            <datestamp>2018-12-07T15:51:41Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434491</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434491</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht in New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Old and New New York</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>Alfred Stieglitz Old and New New York (1910) from: Camera Work No. XXXVI MDCCCCX!</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-224</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>203</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>158</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>280</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>207</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>301</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>207</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">secundaire drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1910</lido:earliestDate>
+                            <lido:latestDate>1910</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434491</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-224</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434491</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{6E84F3AC-66B5-4E41-8353-8F5DF1372EF3}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh6.ggpht.com/nxOnmRIw2umBhlEVUwvrmZNmO7-JwwBqPB4a25qeD5BWDiYaZ2kV5CLqFDvhc6KPABlimkk0smVlFhv--FiFpS26xwhP=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-225.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-225.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-225" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-225</identifier>
+        <datestamp>2018-12-07T14:51:41Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-225</identifier>
+            <datestamp>2018-12-07T15:51:41Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434492</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434492</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Straatgezicht vanuit het raam van Alfred Stieglitz in New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Snapshot - From my Window, New York</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>JES [?] 51880P</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="number">
+                        <lido:inscriptionTranscription>AS 07 [?]</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-225</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>185</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>130</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>295</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>203</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1907</lido:earliestDate>
+                            <lido:latestDate>1907</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/41A33</lido:conceptID>
+                            <lido:term lido:pref="alternative">41A33</lido:term>
+                            <lido:term xml:lang="en">window</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434492</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-225</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434492</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{9597426F-37B7-4556-BF4D-B2B29F3CE5C0}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/4UgVcbs3Xr-EvGawQlUFy3LkNMPrBlsPjvqDeY9RUOaCwJPl7Kz8vfGrhcYt7XhMbbFnBqO5k_jqQHO75QcFmGjyOkI=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-226.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-226.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-226" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-226</identifier>
+        <datestamp>2018-12-07T14:51:41Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-226</identifier>
+            <datestamp>2018-12-07T15:51:41Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434493</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434493</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Gezicht op het schip de Mauretania in New York</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">The Mauretania</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>Stieglitz "The Mauretania" 1910</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto - geschreven in potlood</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>B</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso - geschreven in pen</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-226</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>209</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>164</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>300</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>209</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">papier</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1910</lido:earliestDate>
+                            <lido:latestDate>1910</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/46C26(+35)</lido:conceptID>
+                            <lido:term lido:pref="alternative">46C26(+35)</lido:term>
+                            <lido:term xml:lang="en">steamsailer (+ propulsion of vehicle, ship, etc. by steam)</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434493</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-226</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434493</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:41</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E66C2DBF-F049-492A-AF46-0DD3403C4551}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/qiM82bHNFlwuRl1FfrD125R_xSxuaIcxATH7DZTjXNFXWCuef2sWFd6O1Z4JQw7CJXobIeb3FMXpi5oeW4h3bYnf6Og=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2005-107-230.xml
+++ b/data/rma/lido/oai/RP-F-2005-107-230.xml
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2005-107-230" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2005-107-230</identifier>
+        <datestamp>2018-12-27T10:44:46Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2005-107-230</identifier>
+            <datestamp>2018-12-27T11:44:46Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/434710</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434710</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.28649</lido:conceptID>
+                        <lido:term xml:lang="en">magazine</lido:term>
+                        <lido:term xml:lang="nl">tijdschrift</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.26882</lido:conceptID>
+                        <lido:term xml:lang="nl">fotoboek</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417204">
+                        <lido:appellationValue xml:lang="nl">Camera Work (A photographic Quarterly. Edited and published by Alfred Stieglitz New York)</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:inscriptionsWrap>
+                      <lido:inscriptions lido:type="title">
+                        <lido:inscriptionTranscription>CAMERA WORK A PHOTOGRAPHIC QUARTERLY EDITED AND PUBLISHED BY ALFRED STIEGLITZ NEW YORK</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="date">
+                        <lido:inscriptionTranscription>NUMBER XXXII MDCCCCX</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">recto kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                      <lido:inscriptions lido:type="annotation">
+                        <lido:inscriptionTranscription>EASTMAN ES PLATINUM In this paper we offer a sepia platinum of highest quality - a new hot bath sepia, rich in tone and printing quality - a pure platinum paper coated on buff stock in two surfaces - smooth and rough. EASTMAN KODAK CO., Rochester, N.Y.</lido:inscriptionTranscription>
+                        <lido:inscriptionDescription>
+                          <lido:descriptiveNoteValue xml:lang="nl">verso kaft - gedrukt</lido:descriptiveNoteValue>
+                        </lido:inscriptionDescription>
+                      </lido:inscriptions>
+                    </lido:inscriptionsWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2005-107-230</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectDescriptionWrap>
+                      <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">nummer XXXII MDCCCCX (nr. 32, 1910)</lido:descriptiveNoteValue>
+                      </lido:objectDescriptionSet>
+                    </lido:objectDescriptionWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>340</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>214</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">thickness</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">dikte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>10</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">kaft</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/publication</lido:conceptID>
+                          <lido:term xml:lang="en">Publication (Event)</lido:term>
+                          <lido:term xml:lang="nl">Publicatie</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.53073</lido:conceptID>
+                              <lido:term xml:lang="en">publisher</lido:term>
+                              <lido:term xml:lang="nl">uitgever</lido:term>
+                            </lido:roleActor>
+                            <lido:attributionQualifierActor xml:lang="en">mentioned on object</lido:attributionQualifierActor>
+                            <lido:attributionQualifierActor xml:lang="nl">vermeld op object</lido:attributionQualifierActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1910</lido:earliestDate>
+                            <lido:latestDate>1910</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2005</lido:earliestDate>
+                            <lido:latestDate>2005</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434711</lido:objectID>
+                            <lido:objectNote>Portret van een vrouw met op de achtergrond Japanse prenten</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434712</lido:objectID>
+                            <lido:objectNote>Schetsende man in rotslandschap</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434713</lido:objectID>
+                            <lido:objectNote>Gezicht op Harlech kasteel</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434714</lido:objectID>
+                            <lido:objectNote>Landschap met water</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434715</lido:objectID>
+                            <lido:objectNote>Gezicht op The White House vanaf het water</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604714</lido:objectID>
+                            <lido:objectNote>Naakte vrouw</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604716</lido:objectID>
+                            <lido:objectNote>Naakte man op de rug gezien</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.604715</lido:objectID>
+                            <lido:objectNote>Ninth Movement</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.434716</lido:objectID>
+                            <lido:objectNote>Portret van Alvin Langdon Coburn en zijn moeder</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P46_is_composed_of</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                      <lido:creditLine xml:lang="en">Purchased with the support of the BankGiro Lottery, the Paul Huf Fonds/Rijksmuseum Fonds and the Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Aankoop met steun van de BankGiro Loterij, het Paul Huf Fonds/Rijksmuseum Fonds en het Johan Huizinga Fonds/Rijksmuseum Fonds</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">434710</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2005-107-230</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.434710</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-27T11:44:46</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{A6ECBD07-FCA3-458C-A85E-5F88A99DDB0D}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh4.ggpht.com/GaBkSdRmiBzzuci7d0LPxQALBTL5veUxLn1Rc-kLfrjA2bo-kYeIiJzOW71OMb1GS_PO39PowMDNLfGzJZcAphKvrdFa=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2012-11.xml
+++ b/data/rma/lido/oai/RP-F-2012-11.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2012-11" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2012-11</identifier>
+        <datestamp>2018-12-07T14:52:07Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2012-11</identifier>
+            <datestamp>2018-12-07T15:52:07Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/510885</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.510885</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">An Icy Night</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2012-11</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectDescriptionWrap>
+                      <lido:objectDescriptionSet>
+                        <lido:descriptiveNoteValue xml:lang="nl">Nachtfoto: met ijs bedekte bomen aan Park Avenue (bij 63rd Street), New York City.</lido:descriptiveNoteValue>
+                      </lido:objectDescriptionSet>
+                    </lido:objectDescriptionWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>129</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>159</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>205</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>298</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1898-01</lido:earliestDate>
+                            <lido:latestDate>1903</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300015012</lido:conceptID>
+                              <lido:term xml:lang="en">ink</lido:term>
+                              <lido:term xml:lang="nl">inkt</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2012</lido:earliestDate>
+                            <lido:latestDate>2012</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.95</lido:conceptID>
+                          <lido:term xml:lang="en">purchase</lido:term>
+                          <lido:term xml:lang="nl">aankoop</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/25I141</lido:conceptID>
+                            <lido:term lido:pref="alternative">25I141</lido:term>
+                            <lido:term xml:lang="en">street</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/26D</lido:conceptID>
+                            <lido:term lido:pref="alternative">26D</lido:term>
+                            <lido:term xml:lang="en">frost, freezing weather</lido:term>
+                            <lido:term xml:lang="nl">vorst, vrieskou</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectPlace>
+                            <lido:place>
+                              <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                              <lido:namePlaceSet>
+                                <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                                <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                              </lido:namePlaceSet>
+                            </lido:place>
+                          </lido:subjectPlace>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                    <lido:relatedWorksWrap>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/219504</lido:objectID>
+                            <lido:objectNote>Électricité : ten advertising photographs by Man Ray</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                      <lido:relatedWorkSet>
+                        <lido:relatedWork>
+                          <lido:object>
+                            <lido:objectID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">https://library.rijksmuseum.nl/bib/219502</lido:objectID>
+                            <lido:objectNote>Électricité : tien reclamefoto's van Man Ray</lido:objectNote>
+                          </lido:object>
+                        </lido:relatedWork>
+                        <lido:relatedWorkRelType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">P70i_is_documented_in</lido:conceptID>
+                        </lido:relatedWorkRelType>
+                      </lido:relatedWorkSet>
+                    </lido:relatedWorksWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:term xml:lang="en">copyright</lido:term>
+                        <lido:term xml:lang="nl">auteursrecht</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>erven Alfred Stieglitz/Pictoright</lido:appellationValue>
+                        </lido:legalBodyName>
+                      </lido:rightsHolder>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">510885</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2012-11</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.510885</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:52:07</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E1F66DFE-40AA-4B33-AB85-E4E7890EDB36}</lido:resourceID>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsHolder>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>erven Alfred Stieglitz/Pictoright</lido:appellationValue>
+                          </lido:legalBodyName>
+                        </lido:rightsHolder>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2017-206-25.xml
+++ b/data/rma/lido/oai/RP-F-2017-206-25.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2017-206-25" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2017-206-25</identifier>
+        <datestamp>2019-07-17T02:39:18Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2017-206-25</identifier>
+            <datestamp>2019-07-17T04:39:18Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/712236</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.712236</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">A Snapshot</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2017-206-25</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>137</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>169</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">beeld</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>280</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>200</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>296</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>210</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">secundaire drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1911</lido:earliestDate>
+                            <lido:latestDate>1911</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/tgn/7008038</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">Paris</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Parijs</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2018-03-21</lido:earliestDate>
+                            <lido:latestDate>2018-03-21</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.257</lido:conceptID>
+                          <lido:term xml:lang="en">loan</lido:term>
+                          <lido:term xml:lang="nl">bruikleen</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:creditLine xml:lang="en">On loan from J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Bruikleen van J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">712236</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2017-206-25</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.712236</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-07-17T04:39:18</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{B46EEDBD-8567-47CD-9DAB-4E488B241076}</lido:resourceID>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-2017-206-26.xml
+++ b/data/rma/lido/oai/RP-F-2017-206-26.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-2017-206-26" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-2017-206-26</identifier>
+        <datestamp>2019-07-17T02:39:28Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-2017-206-26</identifier>
+            <datestamp>2019-07-17T04:39:28Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/712237</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.712237</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Flat Iron Building</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-2017-206-26</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>168</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>84</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>293</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>208</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">drager</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1903</lido:earliestDate>
+                            <lido:latestDate>1903</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.35951</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">New York (city)</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">New York</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300014224</lido:conceptID>
+                              <lido:term xml:lang="en">cardboard</lido:term>
+                              <lido:term xml:lang="nl">karton</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>2018-03-21</lido:earliestDate>
+                            <lido:latestDate>2018-03-21</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.257</lido:conceptID>
+                          <lido:term xml:lang="en">loan</lido:term>
+                          <lido:term xml:lang="nl">bruikleen</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:creditLine xml:lang="en">On loan from J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                      <lido:creditLine xml:lang="nl">Bruikleen van J. Janse-de Ronde Bresser, Amsterdam</lido:creditLine>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">712237</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-2017-206-26</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.712237</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2019-07-17T04:39:28</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{D749A24D-D972-4E04-BC56-88785C75C1DA}</lido:resourceID>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F11219.xml
+++ b/data/rma/lido/oai/RP-F-F11219.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F11219" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F11219</identifier>
+        <datestamp>2018-09-07T13:51:34Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F11219</identifier>
+            <datestamp>2018-09-07T15:51:34Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/273988</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.273988</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300162872</lido:conceptID>
+                        <lido:term xml:lang="en">stereograph</lido:term>
+                        <lido:term xml:lang="nl">stereofoto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Wildey Monument, Baltimore, Md.</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F11219</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.85069</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Chase, William Merrit</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1849-11-01</lido:earliestDate>
+                                <lido:latestDate>1916-10-15</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1860</lido:earliestDate>
+                            <lido:latestDate>1890</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58618</lido:conceptID>
+                          <lido:term xml:lang="en">third quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">derde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                          <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri">http://browser.aat-ned.nl/300054225</lido:conceptID>
+                              <lido:term xml:lang="nl">fotografie</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">273988</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F11219</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.273988</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-09-07T15:51:34</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{46F5799D-A617-4D2D-81B9-55BB98BC7DD7}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.googleusercontent.com/sufs9OtRmNnZLFCaDQhLRsmctAW_ptkmQ22GHc7zqTCmGXig_6eqU4WAgIeK6ANZXOkQqnmlztbRGmFUdEzFLDLSJOE=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F17653.xml
+++ b/data/rma/lido/oai/RP-F-F17653.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F17653" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F17653</identifier>
+        <datestamp>2018-12-07T14:51:36Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F17653</identifier>
+            <datestamp>2018-12-07T15:51:36Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/250840</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.250840</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van Katherine Stieglitz</lido:appellationValue>
+                      </lido:titleSet>
+                      <lido:titleSet lido:type="http://vocab.getty.edu/aat/300417202">
+                        <lido:appellationValue xml:lang="nl">Katherine, 1905</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17653</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>207</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>169</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>302</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>210</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1905</lido:earliestDate>
+                            <lido:latestDate>1905</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2(STIEGLITZ, KATHERINE)11</lido:conceptID>
+                            <lido:term lido:pref="alternative">61BB2(STIEGLITZ, KATHERINE)11</lido:term>
+                            <lido:term xml:lang="en">historical person (STIEGLITZ, KATHERINE) - BB - woman - historical person (STIEGLITZ, KATHERINE) portrayed alone</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">250840</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17653</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.250840</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:36</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{49D349A6-0AAE-46AC-90C6-1C85B419D2F3}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/OMhTm9j-w2raFpA14Mg3nLmdq9laGUGXXc9EWV_-qp_0wRfGB2Gzu5JZkTXEFcTHI7U5LoKEH8y70tEaDAMg6Z_QBP8=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F17770.xml
+++ b/data/rma/lido/oai/RP-F-F17770.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F17770" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F17770</identifier>
+        <datestamp>2018-12-07T14:51:36Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F17770</identifier>
+            <datestamp>2018-12-07T15:51:36Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/251878</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.251878</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Spring 1901</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17770</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1901</lido:earliestDate>
+                            <lido:latestDate>1901</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">251878</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17770</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.251878</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:36</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{F869F3E0-4D5E-42F1-92A8-D1842AEB3569}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh5.ggpht.com/IMPbjXF-ai5mIV7FVJybmR3vMJRGApixjs1tVIyyG7qcfYJiMdXGW7Rzv6iajPdcdruSTvbR9jFtPNx7OnxqEE1m2cw=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F17771.xml
+++ b/data/rma/lido/oai/RP-F-F17771.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F17771" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F17771</identifier>
+        <datestamp>2018-12-07T14:51:37Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F17771</identifier>
+            <datestamp>2018-12-07T15:51:37Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/251879</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.251879</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">Portret van Miss S.R</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F17771</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>205</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>140</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">foto</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>300</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                            <lido:measurementValue>207</lido:measurementValue>
+                          </lido:measurementsSet>
+                          <lido:extentMeasurements xml:lang="nl">blad</lido:extentMeasurements>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1904</lido:earliestDate>
+                            <lido:latestDate>1904</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58552</lido:conceptID>
+                          <lido:term xml:lang="en">first quarter 20st century</lido:term>
+                          <lido:term xml:lang="nl">eerste kwart 20e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventPlace>
+                          <lido:place>
+                            <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://vocab.getty.edu/page/tgn/7012149</lido:placeID>
+                            <lido:namePlaceSet>
+                              <lido:appellationValue xml:lang="en">United States of America</lido:appellationValue>
+                              <lido:appellationValue xml:lang="nl">Verenigde Staten van Amerika</lido:appellationValue>
+                            </lido:namePlaceSet>
+                          </lido:place>
+                        </lido:eventPlace>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/material">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300014109</lido:conceptID>
+                              <lido:term xml:lang="en">paper</lido:term>
+                              <lido:term xml:lang="nl">papier</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                  <lido:objectRelationWrap>
+                    <lido:subjectWrap>
+                      <lido:subjectSet>
+                        <lido:subject>
+                          <lido:subjectConcept>
+                            <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://iconclass.org">http://iconclass.org/61BB2</lido:conceptID>
+                            <lido:term lido:pref="alternative">61BB2</lido:term>
+                            <lido:term xml:lang="en">historical persons - BB - woman</lido:term>
+                          </lido:subjectConcept>
+                        </lido:subject>
+                      </lido:subjectSet>
+                    </lido:subjectWrap>
+                  </lido:objectRelationWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">251879</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F17771</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.251879</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-12-07T15:51:37</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{E1BE0379-EB74-47C6-AEC4-CF99ADD673E4}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource>http://lh3.ggpht.com/RCojphXB3EN808tGOX6VM4FNl7FbxVobZFvRyCGkngTQyNgRGzrWWC1ujEF-FXRn2pWUuo57RWTuG-3VXbJ9rXfmB1k=s0</lido:linkResource>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F25501-BW.xml
+++ b/data/rma/lido/oai/RP-F-F25501-BW.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F25501-BW" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F25501-BW</identifier>
+        <datestamp>2018-09-06T14:23:28Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F25501-BW</identifier>
+            <datestamp>2018-09-06T16:23:28Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/281435</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.281435</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">L'Hiver, cinquieme avenue</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F25501-BW</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1896</lido:earliestDate>
+                            <lido:latestDate>1896</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                          <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.70528</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Fillon &amp; Heuse</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">281435</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F25501-BW</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.281435</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-09-06T16:23:28</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{0B402D6A-E29D-42F7-949C-9753D0A5DC1B}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/data/rma/lido/oai/RP-F-F25501-BX.xml
+++ b/data/rma/lido/oai/RP-F-F25501-BX.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rm="http://rijksmuseum.nl/collection" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <responseDate>2019-07-29T18:49:31Z</responseDate>
+  <request verb="GetRecord" identifier="oai:rijksmuseum.nl:RP-F-F25501-BX" metadataPrefix="lido" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">https://www.rijksmuseum.nl/api/oai/hABtMJcb</request>
+  <GetRecord xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <record>
+      <header>
+        <identifier>oai:rijksmuseum.nl:RP-F-F25501-BX</identifier>
+        <datestamp>2018-09-06T14:23:28Z</datestamp>
+      </header>
+      <metadata>
+        <record xmlns:lido="http://www.lido-schema.org">
+          <header>
+            <identifier>oai:rijksmuseum.nl:RP-F-F25501-BX</identifier>
+            <datestamp>2018-09-06T16:23:28Z</datestamp>
+          </header>
+          <metadata>
+            <lido:lidoWrap xsi:schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+              <lido:lido>
+                <lido:lidoRecID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">NL-AsdRM/lido/281436</lido:lidoRecID>
+                <lido:objectPublishedID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">http://hdl.handle.net/10934/RM0001.COLLECT.281436</lido:objectPublishedID>
+                <lido:descriptiveMetadata xml:lang="en">
+                  <lido:objectClassificationWrap>
+                    <lido:objectWorkTypeWrap>
+                      <lido:objectWorkType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://vocab.getty.edu/aat">http://vocab.getty.edu/aat/300046300</lido:conceptID>
+                        <lido:term xml:lang="en">photograph</lido:term>
+                        <lido:term xml:lang="nl">foto</lido:term>
+                      </lido:objectWorkType>
+                    </lido:objectWorkTypeWrap>
+                    <lido:classificationWrap>
+                      <lido:classification lido:type="http://vocab.getty.edu/aat/300025976">
+                        <lido:term xml:lang="nl">foto's</lido:term>
+                      </lido:classification>
+                    </lido:classificationWrap>
+                  </lido:objectClassificationWrap>
+                  <lido:objectIdentificationWrap>
+                    <lido:titleWrap>
+                      <lido:titleSet>
+                        <lido:appellationValue xml:lang="nl">L'Hiver, cinquieme avenue</lido:appellationValue>
+                      </lido:titleSet>
+                    </lido:titleWrap>
+                    <lido:repositoryWrap>
+                      <lido:repositorySet>
+                        <lido:repositoryName>
+                          <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                          <lido:legalBodyName>
+                            <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                          </lido:legalBodyName>
+                          <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                        </lido:repositoryName>
+                        <lido:workID lido:type="inventory number">RP-F-F25501-BX</lido:workID>
+                        <lido:repositoryLocation>
+                          <lido:placeID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://sws.geonames.org/">http://sws.geonames.org/6884785</lido:placeID>
+                          <lido:namePlaceSet>
+                            <lido:appellationValue>Rijksmuseum Amsterdam</lido:appellationValue>
+                          </lido:namePlaceSet>
+                        </lido:repositoryLocation>
+                      </lido:repositorySet>
+                    </lido:repositoryWrap>
+                    <lido:objectMeasurementsWrap>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">height</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">hoogte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                      <lido:objectMeasurementsSet>
+                        <lido:objectMeasurements>
+                          <lido:measurementsSet>
+                            <lido:measurementType xml:lang="en">width</lido:measurementType>
+                            <lido:measurementType xml:lang="nl">breedte</lido:measurementType>
+                            <lido:measurementUnit xml:lang="en">mm</lido:measurementUnit>
+                            <lido:measurementUnit xml:lang="nl">mm</lido:measurementUnit>
+                          </lido:measurementsSet>
+                        </lido:objectMeasurements>
+                      </lido:objectMeasurementsSet>
+                    </lido:objectMeasurementsWrap>
+                  </lido:objectIdentificationWrap>
+                  <lido:eventWrap>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.16581</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Stieglitz, Alfred</lido:appellationValue>
+                              </lido:nameActorSet>
+                              <lido:nationalityActor>
+                                <lido:term xml:lang="nl">Amerikaans</lido:term>
+                              </lido:nationalityActor>
+                              <lido:vitalDatesActor>
+                                <lido:earliestDate>1864-01-01</lido:earliestDate>
+                                <lido:latestDate>1946-07-13</lido:latestDate>
+                              </lido:vitalDatesActor>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.48960</lido:conceptID>
+                              <lido:term xml:lang="nl">fotograaf</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1896</lido:earliestDate>
+                            <lido:latestDate>1896</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:periodName>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.58553</lido:conceptID>
+                          <lido:term xml:lang="en">fourth quarter 19th century</lido:term>
+                          <lido:term xml:lang="nl">vierde kwart 19e eeuw</lido:term>
+                        </lido:periodName>
+                        <lido:eventMaterialsTech>
+                          <lido:materialsTech>
+                            <lido:termMaterialsTech lido:type="http://terminology.lido-schema.org/termMaterialsTech_type/technique">
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.14896</lido:conceptID>
+                              <lido:term xml:lang="nl">heliogravure</lido:term>
+                            </lido:termMaterialsTech>
+                          </lido:materialsTech>
+                        </lido:eventMaterialsTech>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/expression_creation</lido:conceptID>
+                          <lido:term xml:lang="en">Expression creation</lido:term>
+                        </lido:eventType>
+                        <lido:eventActor>
+                          <lido:actorInRole>
+                            <lido:actor lido:type="http://terminology.lido-schema.org/actor_type/person">
+                              <lido:actorID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.PEOPLE.70528</lido:actorID>
+                              <lido:nameActorSet>
+                                <lido:appellationValue xml:lang="nl">Fillon &amp; Heuse</lido:appellationValue>
+                              </lido:nameActorSet>
+                            </lido:actor>
+                            <lido:roleActor>
+                              <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.29052</lido:conceptID>
+                              <lido:term xml:lang="en">printer</lido:term>
+                              <lido:term xml:lang="nl">drukker</lido:term>
+                            </lido:roleActor>
+                          </lido:actorInRole>
+                        </lido:eventActor>
+                      </lido:event>
+                    </lido:eventSet>
+                    <lido:eventSet>
+                      <lido:event>
+                        <lido:eventType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/eventType">http://terminology.lido-schema.org/eventType/acquisition</lido:conceptID>
+                          <lido:term xml:lang="en">Acquisition</lido:term>
+                          <lido:term xml:lang="nl">Acquisitie</lido:term>
+                        </lido:eventType>
+                        <lido:eventDate>
+                          <lido:date>
+                            <lido:earliestDate>1994</lido:earliestDate>
+                            <lido:latestDate>1994</lido:latestDate>
+                          </lido:date>
+                        </lido:eventDate>
+                        <lido:eventMethod>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">RM0001.THESAU.766</lido:conceptID>
+                          <lido:term xml:lang="en">transfer</lido:term>
+                          <lido:term xml:lang="nl">overdracht van beheer</lido:term>
+                        </lido:eventMethod>
+                      </lido:event>
+                    </lido:eventSet>
+                  </lido:eventWrap>
+                </lido:descriptiveMetadata>
+                <lido:administrativeMetadata xml:lang="en">
+                  <lido:rightsWorkWrap>
+                    <lido:rightsWorkSet>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                        <lido:term>Public Domain Mark 1.0</lido:term>
+                      </lido:rightsType>
+                    </lido:rightsWorkSet>
+                  </lido:rightsWorkWrap>
+                  <lido:recordWrap>
+                    <lido:recordID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">281436</lido:recordID>
+                    <lido:recordType>
+                      <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://terminology.lido-schema.org/recordType">http://terminology.lido-schema.org/recordType/item-level_record</lido:conceptID>
+                      <lido:term>Item-level record</lido:term>
+                    </lido:recordType>
+                    <lido:recordSource>
+                      <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                      <lido:legalBodyName>
+                        <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                      </lido:legalBodyName>
+                      <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                    </lido:recordSource>
+                    <lido:recordRights>
+                      <lido:rightsType>
+                        <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/zero/1.0/</lido:conceptID>
+                        <lido:term>CC0 1.0 Universal (CC0 1.0)</lido:term>
+                      </lido:rightsType>
+                      <lido:rightsHolder>
+                        <lido:legalBodyID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="ISIL (ISO 15511)">NL-AsdRM</lido:legalBodyID>
+                        <lido:legalBodyName>
+                          <lido:appellationValue>Rijksmuseum</lido:appellationValue>
+                        </lido:legalBodyName>
+                        <lido:legalBodyWeblink>https://www.rijksmuseum.nl/</lido:legalBodyWeblink>
+                      </lido:rightsHolder>
+                      <lido:creditLine>Rijksmuseum</lido:creditLine>
+                    </lido:recordRights>
+                    <lido:recordInfoSet>
+                      <lido:recordInfoID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">oai:rijksmuseum.nl:RP-F-F25501-BX</lido:recordInfoID>
+                      <lido:recordInfoLink lido:formatResource="html">http://hdl.handle.net/10934/RM0001.COLLECT.281436</lido:recordInfoLink>
+                      <lido:recordMetadataDate>2018-09-06T16:23:28</lido:recordMetadataDate>
+                    </lido:recordInfoSet>
+                  </lido:recordWrap>
+                  <lido:resourceWrap>
+                    <lido:resourceSet>
+                      <lido:resourceID lido:type="http://terminology.lido-schema.org/identifier_type/local_identifier">{EB2B008A-8C30-4BBE-B4E8-BDBBEFF31D43}</lido:resourceID>
+                      <lido:resourceRepresentation lido:type="http://terminology.lido-schema.org/resourceRepresentation_type/provided_image">
+                        <lido:linkResource/>
+                      </lido:resourceRepresentation>
+                      <lido:resourceDescription lido:type="download"/>
+                      <lido:rightsResource>
+                        <lido:rightsType>
+                          <lido:conceptID lido:type="http://terminology.lido-schema.org/identifier_type/uri" lido:source="http://creativecommons.org">https://creativecommons.org/publicdomain/mark/1.0/</lido:conceptID>
+                          <lido:term>Public Domain Mark 1.0</lido:term>
+                        </lido:rightsType>
+                        <lido:creditLine>Rijksmuseum</lido:creditLine>
+                      </lido:rightsResource>
+                    </lido:resourceSet>
+                  </lido:resourceWrap>
+                </lido:administrativeMetadata>
+              </lido:lido>
+            </lido:lidoWrap>
+          </metadata>
+        </record>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>


### PR DESCRIPTION
Objects related to O'Keeffe in the Rijksmuseum collection. The data is formatted in XML and modelled according to the LIDO datamodel.

Included are works by Stieglitz:
https://www.rijksmuseum.nl/nl/zoeken?p=1&ps=12&involvedMaker=Alfred+Stieglitz&st=Objects
and one by William Merrit Chase:
https://www.rijksmuseum.nl/nl/zoeken?p=1&ps=12&involvedMaker=William+Merrit+Chase&st=Objects

The exact object numbers and API calls (without API key):
BI-F-B0447-2-1-5
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:BI-F-B0447-2-1-5
RP-F-00-44
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-00-44
RP-F-2001-7-964-21
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-964-21
RP-F-2001-7-968-3-81
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-81
RP-F-2001-7-968-3-90
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-90
RP-F-2001-7-968-3-188
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-188
RP-F-2001-7-968-3-189
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-189
RP-F-2001-7-968-3-190
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-190
RP-F-2001-7-968-3-191
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-191
RP-F-2001-7-968-3-192
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-192
RP-F-2001-7-968-3-197
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-3-197
RP-F-2001-7-968-5-172
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-968-5-172
RP-F-2001-7-1104A-2
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1104A-2
RP-F-2001-7-1184B-220
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1184B-220
RP-F-2001-7-1184B-223
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1184B-223
RP-F-2001-7-1187A-13
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1187A-13
RP-F-2001-7-1468-46
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1468-46
RP-F-2001-7-1668-44
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1668-44
RP-F-2001-7-1668-46
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1668-46
RP-F-2001-7-1668-53
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2001-7-1668-53
RP-F-2005-107-218
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-218
RP-F-2005-107-220
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-220
RP-F-2005-107-221
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-221
RP-F-2005-107-222
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-222
RP-F-2005-107-223
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-223
RP-F-2005-107-224
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-224
RP-F-2005-107-225
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-225
RP-F-2005-107-226
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-226
RP-F-2005-107-230
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2005-107-230
RP-F-2012-11
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2012-11
RP-F-2017-206-25
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2017-206-25
RP-F-2017-206-26
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-2017-206-26
RP-F-F17653
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F17653
RP-F-F17770
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F17770
RP-F-F17771
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F17771
RP-F-F25501-BX
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F25501-BX
RP-F-F25501-BW
https://www.rijksmuseum.nl/api/oai/[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F25501-BW

RP-F-F11219
[APIKEY]?verb=GetRecord&metadataPrefix=lido&identifier=oai:rijksmuseum.nl:RP-F-F11219
