### PR TITLE
Initial pass at PUAM objects

### DIFF
--- a/data/puam/11558.json
+++ b/data/puam/11558.json
@@ -1,0 +1,345 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/11558",
+    "type":"HumanMadeObject",
+    "_label":"O’Keeffe painting and picture racks in back room, An American Place, New York",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300046300",
+            "type":"Type",
+            "_label":"photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128695",
+            "type":"Type",
+            "_label":"gelatin silver prints"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1971-192",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":11558,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/11558/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500026108",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/production",
+            "type":"TimeSpan",
+            "_label":"1939",
+            "begin_of_the_begin":"1939-01-01T00:00:00",
+            "end_of_the_end":"1939-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/11558/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/11558/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1971"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"20.9 x 16.2 cm (8 1/4 x 6 3/8 in.)\r\nmount: 45.8 x 35.7 cm. (18 1/16 x 14 1/16 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© The Ansel Adams Publishing Rights Trust",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"20.90",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"16.20",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11558/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11558/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"45.80",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11558/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"35.70",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/11558",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV20162.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/11559.json
+++ b/data/puam/11559.json
@@ -1,0 +1,345 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/11559",
+    "type":"HumanMadeObject",
+    "_label":"Detail of O’Keeffe painting and reflections, An American Place, New York",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300128695",
+            "type":"Type",
+            "_label":"gelatin silver prints"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1971-193",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":11559,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/11559/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500026108",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/production",
+            "type":"TimeSpan",
+            "_label":"1939",
+            "begin_of_the_begin":"1939-01-01T00:00:00",
+            "end_of_the_end":"1939-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/11559/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/11559/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1971"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"18.1 x 22.5 cm (7 1/8 x 8 7/8 in.)\r\nmount: 35.6 x 43.7 cm. (14 x 17 3/16 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© The Ansel Adams Publishing Rights Trust",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"18.10",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"22.50",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11559/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11559/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"35.60",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11559/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"43.70",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/11559",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV20163.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/11962.json
+++ b/data/puam/11962.json
@@ -1,0 +1,345 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/11962",
+    "type":"HumanMadeObject",
+    "_label":"Georgia O'Keeffe, Ghost Ranch, New Mexico",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300128695",
+            "type":"Type",
+            "_label":"gelatin silver prints"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1971-280",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":11962,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/11962/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500007426",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/production",
+            "type":"TimeSpan",
+            "_label":"1945",
+            "begin_of_the_begin":"1945-01-01T00:00:00",
+            "end_of_the_end":"1945-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/11962/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/11962/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1971"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"23.5 x 19.1 cm (9 1/4 x 7 1/2 in.)\r\nmount: 48 x 38 cm. (18 7/8 x 14 15/16 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© Amon Carter Museum of American Art, Fort Worth, Texas",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"23.50",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"19.10",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/11962/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11962/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"48.00",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/11962/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"38.00",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/11962",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV21039.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/12053.json
+++ b/data/puam/12053.json
@@ -1,0 +1,238 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/12053",
+    "type":"HumanMadeObject",
+    "_label":"O'Keeffe Hands with Thimble",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300154372",
+            "type":"Type",
+            "_label":"relief halftones"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1971-334 i",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":12053,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/12053/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500024301",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/production",
+            "type":"TimeSpan",
+            "_label":"1919",
+            "begin_of_the_begin":"1919-01-01T00:00:00",
+            "end_of_the_end":"1919-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/12053/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/12053/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1971"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"image: 18.8 x 15.2 cm. (7 3/8 x 6 in.)\r\nsheet: 42 x 35 cm. (16 9/16 x 13 3/4 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12053/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Halftone print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/NoC-US/1.0/",
+            "type":"LinguisticObject",
+            "_label":"No Copyright - United States",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/12053",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV20770.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/12057.json
+++ b/data/puam/12057.json
@@ -1,0 +1,238 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/12057",
+    "type":"HumanMadeObject",
+    "_label":"Portrait – Georgia O'Keeffe",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300154372",
+            "type":"Type",
+            "_label":"relief halftones"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1971-334 j",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":12057,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/12057/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500024301",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/production",
+            "type":"TimeSpan",
+            "_label":"1929",
+            "begin_of_the_begin":"1929-01-01T00:00:00",
+            "end_of_the_end":"1929-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/12057/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/12057/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1971"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"image: 18.8 x 15.2 cm. (7 3/8 x 6 in.)\r\nsheet: 42 x 35 cm. (16 9/16 x 13 3/4 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/12057/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Halftone print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/NoC-US/1.0/",
+            "type":"LinguisticObject",
+            "_label":"No Copyright - United States",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/12057",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV20771.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/14456.json
+++ b/data/puam/14456.json
@@ -1,0 +1,345 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/14456",
+    "type":"HumanMadeObject",
+    "_label":"Georgia O'Keeffe and Orville Cox",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300046300",
+            "type":"Type",
+            "_label":"photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128695",
+            "type":"Type",
+            "_label":"gelatin silver prints"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1981-89",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":14456,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/14456/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500026108",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/production",
+            "type":"TimeSpan",
+            "_label":"1937, printed 1980",
+            "begin_of_the_begin":"1937, printed 1980-01-01T00:00:00",
+            "end_of_the_end":"1937, printed 1980-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/14456/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/14456/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1981"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of Nils A. Lundberg",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"19 x 26.8 cm (7 1/2 x 10 9/16 in.)\r\nmount: 40.7 x 50.7 cm. (16 x 19 15/16 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© The Ansel Adams Publishing Rights Trust",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"19.00",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"26.80",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14456/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/14456/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"40.70",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/14456/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"50.70",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/14456",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV16602.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/14878.json
+++ b/data/puam/14878.json
@@ -1,0 +1,363 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/14878",
+    "type":"HumanMadeObject",
+    "_label":"Narcissa's Last Orchid",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300033973",
+            "type":"Type",
+            "_label":"drawings"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300076922",
+            "type":"Type",
+            "_label":"pastels"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"x1982-357",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":14878,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/14878/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500018666",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/production",
+            "type":"TimeSpan",
+            "_label":"1940",
+            "begin_of_the_begin":"1940-01-01T00:00:00",
+            "end_of_the_end":"1940-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/14878/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/14878/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1982"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/6",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Prints and Drawings Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David H. McAlpin, Class of 1920",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"54.5 x 69.1 cm (21 7/16 x 27 3/16 in.)\r\nframe: 74.5 × 89.7 × 4.5 cm (29 5/16 × 35 5/16 × 1 3/4 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Pastel",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© Georgia O'Keeffe Museum / Artists Rights Society (ARS), New York",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"54.50",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"69.10",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/14878/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/14878/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"74.50",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/14878/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"89.70",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/14878/mount-1/Depth",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"4.50",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300072633",
+                            "type":"Dimension",
+                            "_label":"depth"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/14878",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/x1982-357.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/33952.json
+++ b/data/puam/33952.json
@@ -1,0 +1,358 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/33952",
+    "type":"HumanMadeObject",
+    "_label":"From a New Jersey Weekend II",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300033799",
+            "type":"Type",
+            "_label":"oil paintings"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"y1994-136",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":33952,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/33952/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500018666",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/production",
+            "type":"TimeSpan",
+            "_label":"1941",
+            "begin_of_the_begin":"1941-01-01T00:00:00",
+            "end_of_the_end":"1941-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/33952/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/33952/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"1994"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/3",
+            "type":"Set",
+            "_label":"Princeton University Art Museum American Art Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of the Georgia O'Keeffe Foundation",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"91.5 x 61 cm. (36 x 24 in.)\r\nframe: 104 × 73.3 × 3 cm (40 15/16 × 28 7/8 × 1 3/16 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Oil on canvas",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/Height",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"91.50",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055644",
+                    "type":"Dimension",
+                    "_label":"height"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/Width",
+            "type":"Dimension",
+            "_label":"Dimensions for the Object",
+            "value":"61.00",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055647",
+                    "type":"Dimension",
+                    "_label":"width"
+                }
+            ],
+            "unit":{
+                "id":"http://vocab.getty.edu/aat/300379098",
+                "type":"Type",
+                "_label":"centimeters"
+            }
+        }
+    ],
+    "part":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/33952/mount-1",
+            "type":"HumanMadeObject",
+            "_label":"Mount part of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300131087",
+                    "type":"Type",
+                    "_label":"mounts (framing and mounting equipment"
+                }
+            ],
+            "dimension":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/33952/mount-1/Height",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"104.00",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055644",
+                            "type":"Dimension",
+                            "_label":"height"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/33952/mount-1/Width",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"73.30",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300055647",
+                            "type":"Dimension",
+                            "_label":"width"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                },
+                {
+                    "id":"https://data.artmuseum.princeton.edu/objects/la/33952/mount-1/Depth",
+                    "type":"Dimension",
+                    "_label":"Mount Dimensions for the Object",
+                    "value":"3.00",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300072633",
+                            "type":"Dimension",
+                            "_label":"depth"
+                        }
+                    ],
+                    "unit":{
+                        "id":"http://vocab.getty.edu/aat/300379098",
+                        "type":"Type",
+                        "_label":"centimeters"
+                    }
+                }
+            ]
+        }
+    ],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/33952",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/y1994-136.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/42020.json
+++ b/data/puam/42020.json
@@ -1,0 +1,261 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/42020",
+    "type":"HumanMadeObject",
+    "_label":"Georgia O’Keeffe, Abiquiu, New Mexico",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300046300",
+            "type":"Type",
+            "_label":"photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300162056",
+            "type":"Type",
+            "_label":"black-and-white photography"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"2003-166",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":42020,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/42020/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500024399",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/production",
+            "type":"TimeSpan",
+            "_label":"1958, printed 1997",
+            "begin_of_the_begin":"1958, printed 1997-01-01T00:00:00",
+            "end_of_the_end":"1958, printed 1997-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/42020/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/42020/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"2003"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"The Peter C. Bunnell Collection, gift of the artist",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"image: 23.5 x 18.1 cm (9 1/4 x 7 1/8 in.)\r\nsheet: 35.4 x 27.9 cm (13 15/16 x 11 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/42020/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"©1997, Don Worth",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/42020",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV16036.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}

--- a/data/puam/51458.json
+++ b/data/puam/51458.json
@@ -1,0 +1,256 @@
+{
+    "@context":"https://linked.art/ns/v1/linked-art.json",
+    "id":"https://data.artmuseum.princeton.edu/objects/la/51458",
+    "type":"HumanMadeObject",
+    "_label":"Georgia O'Keeffe paintings at An American Place, New York",
+    "classified_as":[
+        {
+            "id":"http://vocab.getty.edu/aat/300128695",
+            "type":"Type",
+            "_label":"gelatin silver prints"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300128347",
+            "type":"Type",
+            "_label":"black-and-white photographs"
+        },
+        {
+            "id":"http://vocab.getty.edu/aat/300133025",
+            "type":"Type",
+            "_label":"works of art"
+        }
+    ],
+    "identified_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/accession-number",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Accession Number for the Object",
+            "content":"2006-659",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312355",
+                    "type":"Type",
+                    "_label":"accession numbers"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/objectid",
+            "type":"identifier",
+            "_label":"Princeton University Art Museum Collections Database Number for the Object",
+            "content":51458,
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300404621",
+                    "type":"Type",
+                    "_label":"repository numbers"
+                }
+            ]
+        }
+    ],
+    "produced_by":{
+        "id":"https://data.artmuseum.princeton.edu/objects/la/51458/production",
+        "type":"Production",
+        "_label":"Production of the Object",
+        "carried_out_by":[
+            {
+                "id":"http://vocab.getty.edu/ulan/500026108",
+                "type":"Actor",
+                "_label":"Georgia O'Keeffe"
+            }
+        ],
+        "timespan":{
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/production",
+            "type":"TimeSpan",
+            "_label":"1940",
+            "begin_of_the_begin":"1940-01-01T00:00:00",
+            "end_of_the_end":"1940-12-31T00:00:00"
+        }
+    },
+    "current_owner":[
+        {
+            "id":"http://vocab.getty.edu/ulan/500310237",
+            "type":"Group",
+            "_label":"Princeton University Art Museum",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300312281",
+                    "type":"Type",
+                    "_label":"museums (institutions)"
+                }
+            ],
+            "acquired_title_through":[
+                {
+                    "id":"https://data.artmuseum.princeton.edu/object/la/51458/puam-acquisition",
+                    "type":"Acquisition",
+                    "_label":"Princeton University Art Museum Acquisition of the Object",
+                    "classified_as":[
+                        {
+                            "id":"http://vocab.getty.edu/aat/300157782",
+                            "type":"Type",
+                            "_label":"acquisition (collections management)"
+                        }
+                    ],
+                    "took_place_at":[
+                        {
+                            "id":"http://vocab.getty.edu/tgn/7016190",
+                            "type":"Place",
+                            "_label":"Princeton, New Jersey"
+                        }
+                    ],
+                    "timespan":{
+                        "id":"https://data.discovernewfields.org/object/51458/puam-acquisition/timespan",
+                        "type":"TimeSpan",
+                        "_label":"2006"
+                    }
+                }
+            ]
+        }
+    ],
+    "currentlocation":{
+        "id":"http://data.artmuseum.princeton.edu/locations/storage",
+        "type":"Place",
+        "_label":"Princeton University Art Museum Collection Storage",
+        "classified_as":[
+            {
+                "id":"http://vocab.getty.edu/aat/300265733",
+                "type":"Type",
+                "_label":"museum storerooms"
+            }
+        ]
+    },
+    "member_of":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/collection/8",
+            "type":"Set",
+            "_label":"Princeton University Art Museum Photography Collection"
+        }
+    ],
+    "referred_to_by":[
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/credit-line",
+            "type":"LinguisticObject",
+            "_label":"Princeton University Art Museum Credit Line for the Object",
+            "content":"Gift of David Hunter McAlpin Jr., Class of 1950",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300026687",
+                    "type":"Type",
+                    "_label":"acknowledgments"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/dimension-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Dimensions of the Object",
+            "content":"image: 11.5 x 17 cm. (4 1/2 x 6 11/16 in.)\r\nsheet: 12 x 17.5 cm. (4 3/4 x 6 7/8 in.)",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300266036",
+                    "type":"Type",
+                    "_label":"dimensions"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/materials-statement",
+            "type":"LinguisticObject",
+            "_label":"Notes about the Materials in the Object",
+            "content":"Gelatin silver print",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300010358",
+                    "type":"Type",
+                    "_label":"materials (substances)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"https://data.artmuseum.princeton.edu/objects/la/51458/rights-statement",
+            "type":"LinguisticObject",
+            "_label":"Rights Statement",
+            "content":"© The Ansel Adams Publishing Rights Trust",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        },
+        {
+            "id":"http://rightsstatements.org/vocab/InC/1.0/",
+            "type":"LinguisticObject",
+            "_label":"In Copyright",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300055547",
+                    "type":"Type",
+                    "_label":"legal concepts"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300418049",
+                    "type":"Type",
+                    "_label":"brief texts"
+                }
+            ]
+        }
+    ],
+    "dimension":[],
+    "subject_of":[
+        {
+            "id":"https://artmuseum.princeton.edu/collections/objects/51458",
+            "type":"LinguisticObject",
+            "_label":"Homepage for the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab/getty.edu/aat/300264578",
+                    "type":"Type",
+                    "_label":"Web pages (documents)"
+                },
+                {
+                    "id":"http://vocab.getty.edu/aat/300266277",
+                    "type":"Type",
+                    "_label":"home pages"
+                }
+            ],
+            "format":"text/html"
+        }
+    ],
+    "representation":[
+        {
+            "id":"https://puam-loris.aws.princeton.edu/loris/INV20523.jp2/full/full/0/default.jpg",
+            "type":"VisualItem",
+            "_label":"Primary Image of the Object",
+            "classified_as":[
+                {
+                    "id":"http://vocab.getty.edu/aat/300215302",
+                    "type":"Type",
+                    "_label":"digital images"
+                }
+            ],
+            "format":"image/jpeg"
+        }
+    ]
+}


### PR DESCRIPTION
A first pass at a baseline representation for our set of 10 O'Keeffe/O'Keeffe related works. This is basically an alternate serialization of our existing JSON output, so these can/will be augmented to down the line to expand in a few areas and also to account for elements that aren't necessarily part of our model that would be relevant for the showcase (particularly so for the works where O'Keeffe and her art are depicted in another work). 